### PR TITLE
feat: add render modes in binpacking

### DIFF
--- a/jumanji/environments/combinatorial/binpack/env.py
+++ b/jumanji/environments/combinatorial/binpack/env.py
@@ -11,9 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import itertools
-from typing import Dict, Tuple
+from typing import Dict, Literal, Optional, Tuple, Union
 
 import chex
 import jax
@@ -108,6 +107,9 @@ class BinPack(Environment[State]):
         reward_fn: RewardFn = sparse_linear_reward,
         normalize_dimensions: bool = True,
         debug: bool = False,
+        render_mode: Union[
+            Literal["human", "rgb_array"], env_viewer.RenderMode
+        ] = env_viewer.RenderMode.HUMAN,
     ):
         """Instantiate a BinPack environment.
 
@@ -139,7 +141,9 @@ class BinPack(Environment[State]):
         self.obs_num_ems = obs_num_ems
         self.reward_fn = reward_fn
         self.normalize_dimensions = normalize_dimensions
-        self._env_viewer = env_viewer.BinPackViewer("BinPack")
+        self._env_viewer = env_viewer.BinPackViewer(
+            "BinPack", env_viewer.RenderMode(render_mode)
+        )
         self.debug = debug
 
     def __repr__(self) -> str:
@@ -348,13 +352,13 @@ class BinPack(Environment[State]):
 
         return next_state, timestep
 
-    def render(self, state: State) -> None:
+    def render(self, state: State) -> Optional[jnp.ndarray]:
         """Render the given state of the environment.
 
         Args:
             state: State object containing the current dynamics of the environment.
         """
-        self._env_viewer.render(state)
+        return self._env_viewer.render(state)
 
     def close(self) -> None:
         """Perform any necessary cleanup.

--- a/jumanji/environments/combinatorial/binpack/env.py
+++ b/jumanji/environments/combinatorial/binpack/env.py
@@ -132,6 +132,9 @@ class BinPack(Environment[State]):
             debug: if True, will output an `invalid_ems_from_env` field in the extras returned
                 within timestep. Default to False as computing this metric slows down the
                 environment.
+            render_mode: The mode used to render the environment. Must be one of:
+                - RenderMode.HUMAN: Render the environment on screen.
+                - RenderMode.RGB_ARRAY: Return a jnp.array frame representing the environment.
         """
         self.instance_generator = (
             instance_generator

--- a/jumanji/environments/combinatorial/binpack/env_viewer.py
+++ b/jumanji/environments/combinatorial/binpack/env_viewer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
+import enum
 from typing import List, Optional, Sequence, Tuple, Union
 
 import jax.numpy as jnp
@@ -26,7 +26,7 @@ import jumanji.environments
 from jumanji.environments.combinatorial.binpack.types import State, item_from_space
 
 
-class RenderMode(str, Enum):
+class RenderMode(str, enum.Enum):
     HUMAN = "human"
     RGB_ARRAY = "rgb_array"
 

--- a/jumanji/environments/combinatorial/binpack/env_viewer.py
+++ b/jumanji/environments/combinatorial/binpack/env_viewer.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from enum import Enum
 from typing import List, Optional, Sequence, Tuple, Union
 
+import jax.numpy as jnp
 import matplotlib.animation
 import matplotlib.cm
 import matplotlib.pyplot as plt
@@ -24,11 +26,16 @@ import jumanji.environments
 from jumanji.environments.combinatorial.binpack.types import State, item_from_space
 
 
+class RenderMode(str, Enum):
+    HUMAN = "human"
+    RGB_ARRAY = "rgb_array"
+
+
 class BinPackViewer:
     FONT_STYLE = "monospace"
     FIGURE_SIZE = (6.0, 6.0)
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, render_mode: RenderMode = RenderMode.HUMAN) -> None:
         """
         Viewer for the BinPack environment.
 
@@ -40,7 +47,14 @@ class BinPackViewer:
         # should run. Otherwise the animation will get garbage-collected.
         self._animation: Optional[matplotlib.animation.Animation] = None
 
-    def render(self, state: State) -> None:
+        if render_mode == RenderMode.RGB_ARRAY:
+            self._display = self._display_rgb_array
+        elif render_mode == RenderMode.HUMAN:
+            self._display = self._display_human
+        else:
+            raise ValueError(f"Invalid render mode: {render_mode}")
+
+    def render(self, state: State) -> Optional[jnp.ndarray]:
         """
         Render the given state of the BinPack environment.
 
@@ -54,7 +68,7 @@ class BinPackViewer:
         for entity in entities:
             ax.add_collection3d(entity)
         self._add_overlay(fig, ax, state)
-        self._display(fig)
+        return self._display(fig)
 
     def animation(
         self,
@@ -200,7 +214,7 @@ class BinPackViewer:
         title = " | ".join(key + ": " + value for key, value in metrics)
         fig.suptitle(title, font=self.FONT_STYLE)
 
-    def _display(self, fig: plt.Figure) -> None:
+    def _display_human(self, fig: plt.Figure) -> None:
         if plt.isinteractive():
             # Required to update render when using Jupyter Notebook.
             fig.canvas.draw()
@@ -211,6 +225,10 @@ class BinPackViewer:
             fig.canvas.draw_idle()
             # Block for 2 seconds.
             fig.canvas.start_event_loop(2.0)
+
+    def _display_rgb_array(self, fig: plt.Figure) -> jnp.ndarray:
+        fig.canvas.draw()
+        return jnp.asarray(fig.canvas.buffer_rgba())
 
     def _clear_display(self) -> None:
         if jumanji.environments.is_colab():

--- a/jumanji/environments/combinatorial/binpack/env_viewer.py
+++ b/jumanji/environments/combinatorial/binpack/env_viewer.py
@@ -41,6 +41,9 @@ class BinPackViewer:
 
         Args:
             name: The window name to be used when initialising the window.
+            render_mode: The mode used to render the environment. Must be one of:
+                - RenderMode.HUMAN: Render the environment on screen.
+                - RenderMode.RGB_ARRAY: Return a jnp.array frame representing the environment.
         """
         self._name = name
         # You must store the created Animation in a variable that lives as long as the animation

--- a/jumanji/wrappers.py
+++ b/jumanji/wrappers.py
@@ -581,14 +581,14 @@ class JumanjiToGymWrapper(gym.Env):
         """
         self._key = jax.random.PRNGKey(seed)
 
-    def render(self, mode: str = "human") -> None:
+    def render(self, mode: str = "human") -> Any:
         """Renders the environment.
 
         Args:
             mode: currently not used since Jumanji does not currently support modes.
         """
         del mode
-        self._env.render(self._state)
+        return self._env.render(self._state)
 
     def close(self) -> None:
         """Closes the environment, important for rendering where pygame is imported."""


### PR DESCRIPTION
This PR is a first attempt to create different rendering modes for jumanji environments. It uses the binpacking environment as an example, but it is meant to be generalized and available to all environments. 

This first draft is a proposition of the interface. It uses the same modes as gym (human and rgb_array). 