### PR TITLE
fix: resolve jumanji import crash in non-terminal and non-notebook setting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: trailing-whitespace
         name: "Trailing whitespace fixer"
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
       - id: flake8

--- a/jumanji/environments/__init__.py
+++ b/jumanji/environments/__init__.py
@@ -40,7 +40,7 @@ try:
         if is_colab():
             backend = "inline"
         else:
-            backend = "notebook"
+            backend = ""
         IPython.get_ipython().run_line_magic("matplotlib", backend)
 
 except ImportError as exc:

--- a/jumanji/environments/__init__.py
+++ b/jumanji/environments/__init__.py
@@ -28,6 +28,10 @@ def is_colab() -> bool:
     return "google.colab" in sys.modules
 
 
+def is_notebook() -> bool:
+    return "ipykernel" in sys.modules
+
+
 # In a notebook, force the Matplotlib backend to ngAgg in order for figures to update
 # every time render is called for environments that use Matplotlib
 # for rendering. Without this, only the last render result is shown per figure.
@@ -39,6 +43,8 @@ try:
 
         if is_colab():
             backend = "inline"
+        elif is_notebook():
+            backend = "notebook"
         else:
             backend = ""
         IPython.get_ipython().run_line_magic("matplotlib", backend)


### PR DESCRIPTION
Closes #34. 

Added another condition in the `environments` folder's `__init__.py` to check if `jumanji` is being run inside a non-Colab notebook. When it is not run in a notebook (Colab or otherwise), the `matplotlib` backend is set to an empty string - `IPython` will deduce the correct choice of backend from inspecting the OS. For example, the backend is inferred to be `MacOSX` for MacOS if we run `IPython.get_ipython().run_line_magic("matplotlib", "")`. 