### PR TITLE
fix: change flake8 link from gitlab to github to resolve failing ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: trailing-whitespace
         name: "Trailing whitespace fixer"
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
       - id: flake8


### PR DESCRIPTION
Closes #47.

Fix the CI pipeline failing at the `flake8` linting step by switching from the GitLab link of `flake8` to the GitHub link in `.pre-commit-config.yaml`.
