### PR TITLE
ci: added python 3.7 to github actions

### DIFF
--- a/.github/workflows/tests_linters.yml
+++ b/.github/workflows/tests_linters.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
         os: [ubuntu-latest]
 
     steps:

--- a/jumanji/env.py
+++ b/jumanji/env.py
@@ -15,9 +15,10 @@
 """Abstract environment class"""
 
 import abc
-from typing import Any, Generic, Protocol, Tuple, TypeVar
+from typing import Any, Generic, Tuple, TypeVar
 
 import chex
+from typing_extensions import Protocol
 
 from jumanji import specs
 from jumanji.types import Action, TimeStep

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,7 +1,7 @@
 black==22.3.0
 coverage
 dm-haiku==0.0.5
-flake8==4.0.1
+flake8
 hydra-core~=1.1
 isort==5.10.1
 livereload

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 brax>=0.0.10
 chex>=0.1.3
 dm-env>=1.5
-gym>=0.19.0
+gym
 jax>=0.2.26
 jaxlib>=0.1.74
 matplotlib>=3.3.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 brax>=0.0.10
 chex>=0.1.3
 dm-env>=1.5
-gym
+gym==0.26.2
 jax>=0.2.26
 jaxlib>=0.1.74
 matplotlib>=3.3.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 brax>=0.0.10
 chex>=0.1.3
 dm-env>=1.5
-gym==0.26.2
+gym>=0.22.0
 jax>=0.2.26
 jaxlib>=0.1.74
 matplotlib>=3.3.4


### PR DESCRIPTION
Added Python version 3.7 to the continuous integration pipeline in GitHub Actions. To resolve the failing tests, I had to

- [x] Constrain `gym` to be `>=0.22.0`
- [x] Relax the constraint on `flake8`