### PR TITLE
fix: import protocol from typing extensions to ensure Python 3.7 compatibility

### DIFF
--- a/jumanji/env.py
+++ b/jumanji/env.py
@@ -15,9 +15,10 @@
 """Abstract environment class"""
 
 import abc
-from typing import Any, Generic, Protocol, Tuple, TypeVar
+from typing import Any, Generic, Tuple, TypeVar
 
 import chex
+from typing_extensions import Protocol
 
 from jumanji import specs
 from jumanji.types import Action, TimeStep


### PR DESCRIPTION
Closes #55. 

Imported `Protocol` from `typing_extensions` instead of `typing` to ensure Python 3.7 compatibility. 