### PR TITLE
refactor: binpack instantiation of instance generator

### DIFF
--- a/jumanji/__init__.py
+++ b/jumanji/__init__.py
@@ -90,7 +90,7 @@ register(
     id="BinPack-toy-v0",
     entry_point="jumanji.environments:BinPack",
     kwargs={
-        "instance_generator": "toy",
+        "instance_generator_type": "toy",
         "obs_num_ems": 40,
     },
 )
@@ -100,7 +100,7 @@ register(
     id="BinPack-rand20-v0",
     entry_point="jumanji.environments:BinPack",
     kwargs={
-        "instance_generator": "random",
+        "instance_generator_type": "random",
         "max_num_items": 20,
         "max_num_ems": 80,
         "obs_num_ems": 40,
@@ -111,7 +111,7 @@ register(
     id="BinPack-rand40-v0",
     entry_point="jumanji.environments:BinPack",
     kwargs={
-        "instance_generator": "random",
+        "instance_generator_type": "random",
         "max_num_items": 40,
         "max_num_ems": 200,
         "obs_num_ems": 60,
@@ -122,7 +122,7 @@ register(
     id="BinPack-rand100-v0",
     entry_point="jumanji.environments:BinPack",
     kwargs={
-        "instance_generator": "random",
+        "instance_generator_type": "random",
         "max_num_items": 100,
         "max_num_ems": 300,
         "obs_num_ems": 150,

--- a/jumanji/__init__.py
+++ b/jumanji/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from jumanji.env import Environment
-from jumanji.environments.combinatorial import binpack as _binpack
 from jumanji.registration import make, register, registered_environments
 
 ## Environment Registration
@@ -91,7 +90,7 @@ register(
     id="BinPack-toy-v0",
     entry_point="jumanji.environments:BinPack",
     kwargs={
-        "instance_generator": _binpack.instance_generator.ToyInstanceGenerator(),
+        "instance_generator": "toy",
         "obs_num_ems": 40,
     },
 )
@@ -101,10 +100,9 @@ register(
     id="BinPack-rand20-v0",
     entry_point="jumanji.environments:BinPack",
     kwargs={
-        "instance_generator": _binpack.instance_generator.RandomInstanceGenerator(
-            max_num_items=20,
-            max_num_ems=80,
-        ),
+        "instance_generator": "random",
+        "max_num_items": 20,
+        "max_num_ems": 80,
         "obs_num_ems": 40,
     },
 )
@@ -113,10 +111,9 @@ register(
     id="BinPack-rand40-v0",
     entry_point="jumanji.environments:BinPack",
     kwargs={
-        "instance_generator": _binpack.instance_generator.RandomInstanceGenerator(
-            max_num_items=40,
-            max_num_ems=200,
-        ),
+        "instance_generator": "random",
+        "max_num_items": 40,
+        "max_num_ems": 200,
         "obs_num_ems": 60,
     },
 )
@@ -125,10 +122,9 @@ register(
     id="BinPack-rand100-v0",
     entry_point="jumanji.environments:BinPack",
     kwargs={
-        "instance_generator": _binpack.instance_generator.RandomInstanceGenerator(
-            max_num_items=100,
-            max_num_ems=300,
-        ),
+        "instance_generator": "random",
+        "max_num_items": 100,
+        "max_num_ems": 300,
         "obs_num_ems": 150,
     },
 )

--- a/jumanji/environments/combinatorial/binpack/conftest.py
+++ b/jumanji/environments/combinatorial/binpack/conftest.py
@@ -93,7 +93,9 @@ def dummy_instance(dummy_instance_generator: DummyInstanceGenerator) -> State:
 
 @pytest.fixture
 def binpack_env(dummy_instance_generator: DummyInstanceGenerator) -> BinPack:
-    return BinPack(instance_generator=dummy_instance_generator, obs_num_ems=5)
+    env = BinPack(obs_num_ems=5)
+    env.instance_generator = dummy_instance_generator
+    return env
 
 
 @pytest.fixture

--- a/jumanji/environments/combinatorial/binpack/env.py
+++ b/jumanji/environments/combinatorial/binpack/env.py
@@ -105,7 +105,7 @@ class BinPack(Environment[State]):
 
     def __init__(
         self,
-        instance_generator: str = "toy",
+        instance_generator_type: str = "toy",
         obs_num_ems: int = 60,
         reward_fn: RewardFn = sparse_linear_reward,
         normalize_dimensions: bool = True,
@@ -115,10 +115,10 @@ class BinPack(Environment[State]):
         """Instantiate a BinPack environment.
 
         Args:
-            instance_generator: string representing the InstanceGenerator responsible for resetting
-                the environment. E.g. can be a random generator to learn generalisation or one that
-                outputs the same instance to do active search on that instance.
-                Default to ToyInstanceGenerator that always resets to the same instance
+            instance_generator_type: string representing the InstanceGenerator responsible for
+                resetting the environment. E.g. can be a random generator to learn generalisation
+                or one that outputs the same instance to do active search on that instance.
+                Defaults to ToyInstanceGenerator that always resets to the same instance
                 with 20 items. Possible values: 'toy' (default), 'csv' or 'random'.
             obs_num_ems: number of ems to show to the agent. If `obs_num_ems` is smaller than
                 `generator.max_num_ems`, the first `obs_num_ems` biggest ems will be returned
@@ -136,7 +136,7 @@ class BinPack(Environment[State]):
             instance_generator_kwargs: Keyword arguments for the specified instance generator.
         """
         self.instance_generator = self.create_instance_generator(
-            instance_generator, **instance_generator_kwargs
+            instance_generator_type, **instance_generator_kwargs
         )
 
         self.obs_num_ems = obs_num_ems
@@ -149,7 +149,7 @@ class BinPack(Environment[State]):
         return "\n".join(
             [
                 "BinPack environment:",
-                f" - instance_generator: {self.instance_generator}",
+                f" - instance_generator_type: {self.instance_generator}",
                 f" - max_num_items: {self.instance_generator.max_num_items}",
                 f" - obs_num_ems: {self.obs_num_ems}",
                 f" - max_num_ems: {self.instance_generator.max_num_ems}",
@@ -161,7 +161,7 @@ class BinPack(Environment[State]):
 
     @classmethod
     def create_instance_generator(
-        cls, instance_generator: str, **instance_generator_kwargs: Any
+        cls, instance_generator_type: str, **instance_generator_kwargs: Any
     ) -> InstanceGenerator:
         """
         Factory method for creating an instance generator.
@@ -169,7 +169,7 @@ class BinPack(Environment[State]):
         This method can be overridden to add new instance generator types.
 
         Args:
-            instance_generator: The type of instance generator to create. Possible values:
+            instance_generator_type: The type of instance generator to create. Possible values:
                 - 'toy': Create a toy instance generator.
                 - 'csv': Create a CSV instance generator.
                 - 'random': Create a random instance generator.
@@ -180,21 +180,21 @@ class BinPack(Environment[State]):
             An instance of `InstanceGenerator`.
 
         Raises:
-            ValueError: If an unexpected value is provided for `instance_generator`.
+            ValueError: If an unexpected value is provided for `instance_generator_type`.
         """
         instance_generator_obj: InstanceGenerator
 
-        if instance_generator == "toy":
+        if instance_generator_type == "toy":
             instance_generator_obj = ToyInstanceGenerator()
-        elif instance_generator == "csv":
+        elif instance_generator_type == "csv":
             instance_generator_obj = CSVInstanceGenerator(**instance_generator_kwargs)
-        elif instance_generator == "random":
+        elif instance_generator_type == "random":
             instance_generator_obj = RandomInstanceGenerator(
                 **instance_generator_kwargs
             )
         else:
             raise ValueError(
-                f"Unexpected value for 'instance_generator', got {instance_generator!r}."
+                f"Unexpected value for 'instance_generator_type', got {instance_generator_type!r}."
                 "Possible values: 'toy', 'csv', 'random'."
             )
         return instance_generator_obj

--- a/jumanji/environments/combinatorial/binpack/env.py
+++ b/jumanji/environments/combinatorial/binpack/env.py
@@ -118,7 +118,7 @@ class BinPack(Environment[State]):
             instance_generator_type: string representing the InstanceGenerator responsible for
                 resetting the environment. E.g. can be a random generator to learn generalisation
                 or one that outputs the same instance to do active search on that instance.
-                Defaults to ToyInstanceGenerator that always resets to the same instance
+                Defaults to "toy" which creates a ToyInstanceGenerator that always resets to the same instance
                 with 20 items. Possible values: 'toy' (default), 'csv' or 'random'.
             obs_num_ems: number of ems to show to the agent. If `obs_num_ems` is smaller than
                 `generator.max_num_ems`, the first `obs_num_ems` biggest ems will be returned

--- a/jumanji/environments/combinatorial/binpack/env.py
+++ b/jumanji/environments/combinatorial/binpack/env.py
@@ -118,8 +118,9 @@ class BinPack(Environment[State]):
             instance_generator_type: string representing the InstanceGenerator responsible for
                 resetting the environment. E.g. can be a random generator to learn generalisation
                 or one that outputs the same instance to do active search on that instance.
-                Defaults to "toy" which creates a ToyInstanceGenerator that always resets to the same instance
-                with 20 items. Possible values: 'toy' (default), 'csv' or 'random'.
+                Defaults to "toy" which creates a ToyInstanceGenerator that always resets to
+                the same instance with 20 items.
+                Possible values: 'toy' (default), 'csv' or 'random'.
             obs_num_ems: number of ems to show to the agent. If `obs_num_ems` is smaller than
                 `generator.max_num_ems`, the first `obs_num_ems` biggest ems will be returned
                 in the observation. Default to 60, but the good number heavily depends on the

--- a/jumanji/environments/combinatorial/binpack/env.py
+++ b/jumanji/environments/combinatorial/binpack/env.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import itertools
-from typing import Dict, Tuple
+from typing import Any, Dict, Tuple
 
 import chex
 import jax
@@ -24,7 +24,9 @@ from jumanji import specs
 from jumanji.env import Environment
 from jumanji.environments.combinatorial.binpack import env_viewer
 from jumanji.environments.combinatorial.binpack.instance_generator import (
+    CSVInstanceGenerator,
     InstanceGenerator,
+    RandomInstanceGenerator,
     ToyInstanceGenerator,
 )
 from jumanji.environments.combinatorial.binpack.reward import (
@@ -103,20 +105,21 @@ class BinPack(Environment[State]):
 
     def __init__(
         self,
-        instance_generator: InstanceGenerator = None,
+        instance_generator: str = "toy",
         obs_num_ems: int = 60,
         reward_fn: RewardFn = sparse_linear_reward,
         normalize_dimensions: bool = True,
         debug: bool = False,
+        **instance_generator_kwargs: Any,
     ):
         """Instantiate a BinPack environment.
 
         Args:
-            instance_generator: InstanceGenerator responsible for resetting the environment. E.g.
-                can be a random generator to learn generalisation or one that outputs the same
-                instance to do active search on that instance. It must inherit from the
-                InstanceGenerator abstract class. Default to ToyInstanceGenerator that always
-                resets to the same instance with 20 items.
+            instance_generator: string representing the InstanceGenerator responsible for resetting
+                the environment. E.g. can be a random generator to learn generalisation or one that
+                outputs the same instance to do active search on that instance.
+                Default to ToyInstanceGenerator that always resets to the same instance
+                with 20 items. Possible values: 'toy' (default), 'csv' or 'random'.
             obs_num_ems: number of ems to show to the agent. If `obs_num_ems` is smaller than
                 `generator.max_num_ems`, the first `obs_num_ems` biggest ems will be returned
                 in the observation. Default to 60, but the good number heavily depends on the
@@ -130,12 +133,12 @@ class BinPack(Environment[State]):
             debug: if True, will output an `invalid_ems_from_env` field in the extras returned
                 within timestep. Default to False as computing this metric slows down the
                 environment.
+            instance_generator_kwargs: Keyword arguments for the specified instance generator.
         """
-        self.instance_generator = (
-            instance_generator
-            if instance_generator is not None
-            else ToyInstanceGenerator()
+        self.instance_generator = self.create_instance_generator(
+            instance_generator, **instance_generator_kwargs
         )
+
         self.obs_num_ems = obs_num_ems
         self.reward_fn = reward_fn
         self.normalize_dimensions = normalize_dimensions
@@ -155,6 +158,46 @@ class BinPack(Environment[State]):
                 f" - debug: {self.debug}",
             ]
         )
+
+    @classmethod
+    def create_instance_generator(
+        cls, instance_generator: str, **instance_generator_kwargs: Any
+    ) -> InstanceGenerator:
+        """
+        Factory method for creating an instance generator.
+
+        This method can be overridden to add new instance generator types.
+
+        Args:
+            instance_generator: The type of instance generator to create. Possible values:
+                - 'toy': Create a toy instance generator.
+                - 'csv': Create a CSV instance generator.
+                - 'random': Create a random instance generator.
+            **instance_generator_kwargs:
+                Additional keyword arguments to pass to the instance generator constructor.
+
+        Returns:
+            An instance of `InstanceGenerator`.
+
+        Raises:
+            ValueError: If an unexpected value is provided for `instance_generator`.
+        """
+        instance_generator_obj: InstanceGenerator
+
+        if instance_generator == "toy":
+            instance_generator_obj = ToyInstanceGenerator()
+        elif instance_generator == "csv":
+            instance_generator_obj = CSVInstanceGenerator(**instance_generator_kwargs)
+        elif instance_generator == "random":
+            instance_generator_obj = RandomInstanceGenerator(
+                **instance_generator_kwargs
+            )
+        else:
+            raise ValueError(
+                f"Unexpected value for 'instance_generator', got {instance_generator!r}."
+                "Possible values: 'toy', 'csv', 'random'."
+            )
+        return instance_generator_obj
 
     def observation_spec(self) -> ObservationSpec:
         """Specifications of the observation of the BinPack environment.

--- a/jumanji/environments/combinatorial/binpack/env_test.py
+++ b/jumanji/environments/combinatorial/binpack/env_test.py
@@ -23,8 +23,6 @@ from jumanji import specs, tree_utils
 from jumanji.environments.combinatorial.binpack.env import BinPack
 from jumanji.environments.combinatorial.binpack.instance_generator import (
     InstanceGenerator,
-    RandomInstanceGenerator,
-    ToyInstanceGenerator,
 )
 from jumanji.environments.combinatorial.binpack.space import Space
 from jumanji.environments.combinatorial.binpack.specs import (
@@ -158,10 +156,10 @@ def test_binpack__spec(
     different specs are generated depending on the `normalize_dimensions` argument.
     """
     binpack_env = BinPack(
-        instance_generator=dummy_instance_generator,
         obs_num_ems=1,
         normalize_dimensions=normalize_dimensions,
     )
+    binpack_env.instance_generator = dummy_instance_generator
     observation_spec = binpack_env.observation_spec()
     assert isinstance(observation_spec, ObservationSpec)
     assert isinstance(observation_spec.ems_spec, EMSSpec)
@@ -237,7 +235,7 @@ def test_binpack__optimal_policy_toy_instance(
     policy. Checks for both options: normalizing dimensions and not normalizing.
     """
     toy_binpack = BinPack(
-        ToyInstanceGenerator(),
+        instance_generator="toy",
         obs_num_ems=40,
         normalize_dimensions=normalize_dimensions,
         debug=True,
@@ -278,10 +276,12 @@ def test_binpack__optimal_policy_random_instance(
     two different sizes: 20 items and 40 items.
     """
     random_binpack = BinPack(
-        RandomInstanceGenerator(max_num_items=max_num_items, max_num_ems=max_num_ems),
+        instance_generator="random",
         obs_num_ems=obs_num_ems,
         normalize_dimensions=normalize_dimensions,
         debug=True,
+        max_num_items=max_num_items,
+        max_num_ems=max_num_ems,
     )
     reset_fn = jax.jit(random_binpack.reset)
     generate_solution_fn = jax.jit(random_binpack.instance_generator.generate_solution)

--- a/jumanji/environments/combinatorial/binpack/env_test.py
+++ b/jumanji/environments/combinatorial/binpack/env_test.py
@@ -235,7 +235,7 @@ def test_binpack__optimal_policy_toy_instance(
     policy. Checks for both options: normalizing dimensions and not normalizing.
     """
     toy_binpack = BinPack(
-        instance_generator="toy",
+        instance_generator_type="toy",
         obs_num_ems=40,
         normalize_dimensions=normalize_dimensions,
         debug=True,
@@ -276,7 +276,7 @@ def test_binpack__optimal_policy_random_instance(
     two different sizes: 20 items and 40 items.
     """
     random_binpack = BinPack(
-        instance_generator="random",
+        instance_generator_type="random",
         obs_num_ems=obs_num_ems,
         normalize_dimensions=normalize_dimensions,
         debug=True,

--- a/jumanji/environments/combinatorial/binpack/instance_generator.py
+++ b/jumanji/environments/combinatorial/binpack/instance_generator.py
@@ -178,12 +178,11 @@ class ToyInstanceGenerator(InstanceGenerator):
 
         Example:
             ```python
-            instance_generator = ToyInstanceGenerator()
-            env = BinPack(instance_generator, obs_num_ems=40)
+            env = BinPack(instance_generator_type="toy", obs_num_ems=40)
             key = jax.random.key(0)
-            reset_state = instance_generator(key)
+            reset_state = env.instance_generator(key)
             env.render(reset_state)
-            solution = instance_generator.generate_solution(key)
+            solution = env.instance_generator.generate_solution(key)
             env.render(solution)
             ```
         """
@@ -575,12 +574,11 @@ class RandomInstanceGenerator(InstanceGenerator):
 
     Example:
         ```python
-        instance_generator = RandomInstanceGenerator()
-        env = BinPack(instance_generator)
+        env = BinPack(instance_generator_type="random")
         key = jax.random.key(0)
-        reset_state = instance_generator(key)
+        reset_state = env.instance_generator(key)
         env.render(reset_state)
-        solution = instance_generator.generate_solution(key)
+        solution = env.instance_generator.generate_solution(key)
         env.render(solution)
         ```"""
 
@@ -646,12 +644,11 @@ class RandomInstanceGenerator(InstanceGenerator):
 
         Example:
             ```python
-            instance_generator = RandomInstanceGenerator()
-            env = BinPack(instance_generator)
+            env = BinPack(instance_generator_type="random")
             key = jax.random.key(0)
-            reset_state = instance_generator(key)
+            reset_state = env.instance_generator(key)
             env.render(reset_state)
-            solution = instance_generator.generate_solution(key)
+            solution = env.instance_generator.generate_solution(key)
             env.render(solution)
             ```
         """

--- a/jumanji/wrappers_test.py
+++ b/jumanji/wrappers_test.py
@@ -702,8 +702,8 @@ class TestJumanjiToGymObservation:
 
     def test_jumanji_to_gym_obs__binpack(self) -> None:
         """Check that an example binpack observation is correctly converted."""
-        instance_generator = DummyInstanceGenerator()
-        env = BinPack(instance_generator, obs_num_ems=1)
+        env = BinPack(obs_num_ems=1)
+        env.instance_generator = DummyInstanceGenerator()
         obs = env.observation_spec().generate_value()
 
         converted_obs = jumanji_to_gym_obs(obs)


### PR DESCRIPTION
Resolves #60 

This moves the instantiation of the instance generator for the binpack environment to the init of the binpack env.

Previously - this was done at registration. 