### PR TITLE
fix: solve flake8 error causing ci to fail

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 default_stages: [ "commit", "commit-msg", "push" ]
 default_language_version:
-  python: python3.8
+  python: python3
 
 
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,7 @@ repos:
           - flake8-bugbear
           - flake8-pytest-style
           - flake8-cognitive-complexity
+          - importlib-metadata<5.0
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         name: "Trailing whitespace fixer"
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 3.9.2
     hooks:
       - id: flake8
         name: "Linter"

--- a/jumanji/environments/combinatorial/binpack/env_test.py
+++ b/jumanji/environments/combinatorial/binpack/env_test.py
@@ -65,7 +65,7 @@ def normalize_dimensions(request: pytest.mark.FixtureRequest) -> bool:
     return request.param  # type: ignore
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="function")  # noqa: CCR001
 def binpack_optimal_policy_select_action(  # noqa: CCR001
     request: pytest.mark.FixtureRequest,
 ) -> Callable[[Observation, State], chex.Array]:

--- a/jumanji/environments/combinatorial/routing/env_viewer.py
+++ b/jumanji/environments/combinatorial/routing/env_viewer.py
@@ -63,8 +63,8 @@ class RoutingViewer:
         ]
 
         for _ in range(num_agents):
-            color = rnd.randint(0, 192, 3)
-            self.palette.append((color[0], color[1], color[2]))
+            r, g, b = map(int, rnd.randint(0, 192, 3))
+            self.palette.append((r, g, b))
 
     def render(self, grid: Array, save_img: Optional[str] = None) -> Array:
         """

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -2,8 +2,8 @@ black==22.3.0
 coverage
 dm-haiku==0.0.5
 flake8==3.9.2
-importlib-metadata<5.0
 hydra-core~=1.1
+importlib-metadata<5.0
 isort==5.10.1
 livereload
 mkdocs==1.2.3

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,7 +1,7 @@
 black==22.3.0
 coverage
 dm-haiku==0.0.5
-flake8
+flake8==3.9.2
 hydra-core~=1.1
 isort==5.10.1
 livereload

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -2,6 +2,7 @@ black==22.3.0
 coverage
 dm-haiku==0.0.5
 flake8==3.9.2
+importlib-metadata<5.0
 hydra-core~=1.1
 isort==5.10.1
 livereload


### PR DESCRIPTION
Resolves #63 #62 

- [x] Changed the default Python version in `.pre-commit-config.yaml` 
- [x] Changed the version of `flake8` in `.pre-commit-config.yaml` 
- [x] Added a constraint on `importlib-metadata` in `requirements-dev.txt` and `.pre-commit-config.yaml` 
- [x] Pinned `flake8` in `requirements-dev.txt`
- [x] Suppressed a flake8 error around cognitive complexity