### PR TITLE
feat: increment semantic release

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ If you use Jumanji in your work, please cite the library using:
         and Nathan Grinsztajn and Thomas D. Barrett and Alexandre Laterre},
   title = {Jumanji: Industry-Driven Hardware-Accelerated RL Environments},
   url = {https://github.com/instadeepai/jumanji},
-  version = {0.1.4},
+  version = {0.1.5},
   year = {2022},
 }
 ```

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
-brax>=0.0.10
 chex>=0.1.3
 dm-env>=1.5
+git+https://github.com/google/brax.git
 gym>=0.22.0
 jax>=0.2.26
 jaxlib>=0.1.74

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/google/brax.git#egg=brax
+brax @ git+https://github.com/google/brax
 chex>=0.1.3
 dm-env>=1.5
 gym>=0.22.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 chex>=0.1.3
 dm-env>=1.5
-git+https://github.com/google/brax.git
 gym>=0.22.0
+https://github.com/google/brax.git
 jax>=0.2.26
 jaxlib>=0.1.74
 matplotlib>=3.3.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
+git+https://github.com/google/brax.git#egg=brax
 chex>=0.1.3
 dm-env>=1.5
 gym>=0.22.0
-https://github.com/google/brax.git
 jax>=0.2.26
 jaxlib>=0.1.74
 matplotlib>=3.3.4

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from typing import List
 import setuptools
 from setuptools import setup
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 _CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
- Had to install Brax from source as any version after 0.0.16 (and potentially slightly before) is broken with recent versions of Jax. We will probably remove Brax from Jumanji's dependencies in the future.