### PR TITLE
fix: pygame requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,5 +6,5 @@ jaxlib>=0.1.74
 matplotlib>=3.3.4
 numpy>=1.19.5
 Pillow>=9.0.0
-pygame==2.0.2
+pygame>=2.0.0, != 2.1.3.*
 typing-extensions>=4.0.0


### PR DESCRIPTION
The pygame compatibility issue with python 3.7 first appeared in pygame 2.1.3.dev6 (pygame/pygame@a462721e) and has been fully resolved in 2.2.0.dev2 (pygame/pygame#3723, pygame/pygame#3572, pygame/pygame@aab517c7). Therefore, the requirement tightened in #67 can be relaxed and only pygame 2.1.3.* needs to be excluded.