### PR TITLE
fix(generator_maze): correct definition of width and height

### DIFF
--- a/jumanji/environments/commons/maze_utils/maze_generation.py
+++ b/jumanji/environments/commons/maze_utils/maze_generation.py
@@ -203,8 +203,8 @@ def generate_maze(width: int, height: int, key: chex.PRNGKey) -> chex.Array:
     """Randomly generate a maze.
 
     Args:
-        width: the number of rows of the maze to create.
-        height: the number of columns of the maze to create.
+        width: the number of columns of the maze to create.
+        height: the number of rows of the maze to create.
         key: the Jax random number generation key.
 
     Returns:

--- a/jumanji/environments/routing/cleaner/generator.py
+++ b/jumanji/environments/routing/cleaner/generator.py
@@ -69,7 +69,7 @@ class RandomGenerator(Generator):
         """
         generator_key, state_key = jax.random.split(key)
         maze = maze_generation.generate_maze(
-            self.num_rows, self.num_cols, generator_key
+            self.num_cols, self.num_rows, generator_key
         )
 
         grid = self._adapt_values(maze)

--- a/jumanji/environments/routing/cleaner/generator_test.py
+++ b/jumanji/environments/routing/cleaner/generator_test.py
@@ -36,7 +36,9 @@ class TestRandomGenerator:
         return RandomGenerator(self.HEIGHT, self.WIDTH, self.NUM_AGENTS)
 
     def test_random_instance_generator_values(
-        self, key: chex.PRNGKey, instance_generator: RandomGenerator,
+        self,
+        key: chex.PRNGKey,
+        instance_generator: RandomGenerator,
     ) -> None:
         state = instance_generator(key)
 

--- a/jumanji/environments/routing/cleaner/generator_test.py
+++ b/jumanji/environments/routing/cleaner/generator_test.py
@@ -27,11 +27,11 @@ class TestRandomGenerator:
     HEIGHT = 7
     NUM_AGENTS = 3
 
-    @pytest.fixture()
+    @pytest.fixture
     def key(self) -> chex.PRNGKey:
         return jax.random.PRNGKey(0)
 
-    @pytest.fixture()
+    @pytest.fixture
     def instance_generator(self) -> RandomGenerator:
         return RandomGenerator(self.HEIGHT, self.WIDTH, self.NUM_AGENTS)
 

--- a/jumanji/environments/routing/cleaner/generator_test.py
+++ b/jumanji/environments/routing/cleaner/generator_test.py
@@ -27,16 +27,16 @@ class TestRandomGenerator:
     HEIGHT = 7
     NUM_AGENTS = 3
 
-    @pytest.fixture
+    @pytest.fixture()
     def key(self) -> chex.PRNGKey:
         return jax.random.PRNGKey(0)
 
-    @pytest.fixture
+    @pytest.fixture()
     def instance_generator(self) -> RandomGenerator:
-        return RandomGenerator(self.WIDTH, self.HEIGHT, self.NUM_AGENTS)
+        return RandomGenerator(self.HEIGHT, self.WIDTH, self.NUM_AGENTS)
 
     def test_random_instance_generator_values(
-        self, key: chex.PRNGKey, instance_generator: RandomGenerator
+        self, key: chex.PRNGKey, instance_generator: RandomGenerator,
     ) -> None:
         state = instance_generator(key)
 
@@ -44,4 +44,4 @@ class TestRandomGenerator:
         assert jnp.sum(jnp.logical_and(state.grid != WALL, state.grid != DIRTY)) == 1
         assert state.grid[0, 0] == CLEAN  # Only the top-left tile is clean
         assert state.step_count == 0
-        assert state.grid.shape == (self.WIDTH, self.HEIGHT)
+        assert state.grid.shape == (self.HEIGHT, self.WIDTH)

--- a/jumanji/environments/routing/cleaner/generator_test.py
+++ b/jumanji/environments/routing/cleaner/generator_test.py
@@ -44,3 +44,4 @@ class TestRandomGenerator:
         assert jnp.sum(jnp.logical_and(state.grid != WALL, state.grid != DIRTY)) == 1
         assert state.grid[0, 0] == CLEAN  # Only the top-left tile is clean
         assert state.step_count == 0
+        assert state.grid.shape == (self.WIDTH, self.HEIGHT)


### PR DESCRIPTION
Closes #124.

### Description

The doctring is wrong in the generate_maze function. It states:
```python 
def generate_maze(width: int, height: int, key: chex.PRNGKey) -> chex.Array:
    ...
    Args:
        width: the number of rows of the maze to create.
        height: the number of columns of the maze to create.
```
while it should be:
```python 
def generate_maze(width: int, height: int, key: chex.PRNGKey) -> chex.Array:
    ...
    Args:
        width: the number of columns of the maze to create.
        height: the number of rows of the maze to create.
```

The generator for the cleaner environment is coherent with the wrong docstring, and thus width and height are inversed.