### PR TITLE
fix: put upper bounds on versions of jax and jaxlib

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 chex>=0.1.3,<0.1.6
 dm-env>=1.5
 gym>=0.22.0
-jax>=0.2.26
+jax>=0.2.26,<=0.4.1
 jaxlib>=0.1.74
 matplotlib>=3.3.4
 numpy>=1.19.5

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@ chex>=0.1.3,<0.1.6
 dm-env>=1.5
 gym>=0.22.0
 jax>=0.2.26,<=0.4.1
-jaxlib<=0.4.1
+jaxlib>=0.1.74,<=0.4.1
 matplotlib>=3.3.4
 numpy>=1.19.5
 Pillow>=9.0.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,7 @@ chex>=0.1.3,<0.1.6
 dm-env>=1.5
 gym>=0.22.0
 jax>=0.2.26,<=0.4.1
+jaxlib<=0.4.1
 matplotlib>=3.3.4
 numpy>=1.19.5
 Pillow>=9.0.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,6 @@ chex>=0.1.3,<0.1.6
 dm-env>=1.5
 gym>=0.22.0
 jax>=0.2.26,<=0.4.1
-jaxlib>=0.1.74
 matplotlib>=3.3.4
 numpy>=1.19.5
 Pillow>=9.0.0


### PR DESCRIPTION
Closes #149. 

- Added the constraint `jax<=0.4.1` to `requirements.txt`
- Added the constraint `jaxlib<=0.4.1` (the version associated with JAX version 0.4.1) in `requirements.txt`