### PR TITLE
fix: data copy setup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include requirements/*
+recursive-include *.npy
 
 # remove the test specific files
 recursive-exclude * *_test.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include LICENSE
 include requirements/*
-recursive-include *.npy
+recursive-include * *.npy
 
 # remove the test specific files
 recursive-exclude * *_test.py

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         "dev": _parse_requirements("requirements/requirements-dev.txt"),
         "train": _parse_requirements("requirements/requirements-train.txt"),
     },
-    package_data={"jumanji": ["py.typed"]},
+    package_data={"jumanji": ["*"]},
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         "dev": _parse_requirements("requirements/requirements-dev.txt"),
         "train": _parse_requirements("requirements/requirements-train.txt"),
     },
-    package_data={"jumanji": ["*"]},
+    package_data={"jumanji": ["py.typed"]},
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",


### PR DESCRIPTION
The issue is: .npy files don't get copied during pip setup. A simple fix is to add the line 
`recursive-include * *.npy` in `MANIFEST.in`

The bug reported:
`FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.8/dist-packages/jumanji/environments/logic/sudoku/data/1000_very_easy_puzzles.npy'
Traceback (most recent call last):
File "zathura/train.py", line 25, in <module>
from jumanji.training import utils
File "/usr/local/lib/python3.8/dist-packages/jumanji/__init__.py", line 67, in <module>
database = np.load(os.path.join(sudoku_path, database_file))
File "/usr/local/lib/python3.8/dist-packages/numpy/lib/npyio.py", line 405, in load
fid = stack.enter_context(open(os_fspath(file), "rb"))
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.8/dist-packages/jumanji/environments/logic/sudoku/data/1000_very_easy_puzzles.npy'
Copyright ©2023 InstaDeep`