### PR TITLE
feat: updated checkpoint notebook to use checkpoints from hf model hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![MyPy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Hugging Face](https://img.shields.io/badge/%F0%9F%A4%97-Hugging%20Face-F8D521)](https://huggingface.co/InstaDeepAI)
 
 [**Environments**](#environments-)
 | [**Installation**](#installation-)


### PR DESCRIPTION
Checkpoints for all benchmarks can be found in InstaDeeps Model Hub [page ](https://huggingface.co/InstaDeepAI). 

The naming convention is jumanji-[ENV-NAME]-[ENV-VERSION]-[MODEL]-[TYPE] 

The checkpoint file has the naming convention [ENV-NAME]-[ENV-VERSION]_training_state
Potentially it will be better to have a common `training_state` so that we can programatically pull down checkpoints?