### PR TITLE
feat(2048): environment performance improvements

### DIFF
--- a/jumanji/environments/logic/game_2048/env.py
+++ b/jumanji/environments/logic/game_2048/env.py
@@ -24,6 +24,7 @@ from jumanji import specs
 from jumanji.env import Environment
 from jumanji.environments.logic.game_2048.types import Board, Observation, State
 from jumanji.environments.logic.game_2048.utils import (
+    move,
     move_down,
     move_left,
     move_right,
@@ -181,11 +182,7 @@ class Game2048(Environment[State]):
             timestep: the next timestep.
         """
         # Take the action in the environment: Up, Right, Down, Left.
-        updated_board, additional_reward = jax.lax.switch(
-            action,
-            [move_up, move_right, move_down, move_left],
-            state.board,
-        )
+        updated_board, additional_reward = move(state.board, action)
 
         # Generate new key.
         random_cell_key, new_state_key = jax.random.split(state.key)
@@ -209,7 +206,7 @@ class Game2048(Environment[State]):
             action_mask=action_mask,
             step_count=state.step_count + 1,
             key=new_state_key,
-            score=state.score + additional_reward.astype(float),
+            score=state.score + additional_reward,
         )
 
         # Generate the observation from the environment state.

--- a/jumanji/environments/logic/game_2048/env.py
+++ b/jumanji/environments/logic/game_2048/env.py
@@ -182,7 +182,7 @@ class Game2048(Environment[State]):
             timestep: the next timestep.
         """
         # Take the action in the environment: Up, Right, Down, Left.
-        updated_board, additional_reward = move(state.board, action)
+        updated_board, reward = move(state.board, action)
 
         # Generate new key.
         random_cell_key, new_state_key = jax.random.split(state.key)
@@ -206,7 +206,7 @@ class Game2048(Environment[State]):
             action_mask=action_mask,
             step_count=state.step_count + 1,
             key=new_state_key,
-            score=state.score + additional_reward,
+            score=state.score + reward,
         )
 
         # Generate the observation from the environment state.
@@ -224,12 +224,12 @@ class Game2048(Environment[State]):
         timestep = jax.lax.cond(
             done,
             lambda: termination(
-                reward=additional_reward,
+                reward=reward,
                 observation=observation,
                 extras=extras,
             ),
             lambda: transition(
-                reward=additional_reward,
+                reward=reward,
                 observation=observation,
                 extras=extras,
             ),
@@ -302,10 +302,10 @@ class Game2048(Environment[State]):
         """
         action_mask = jnp.array(
             [
-                jnp.any(move_up(board, final_shift=False)[0] != board),
-                jnp.any(move_right(board, final_shift=False)[0] != board),
-                jnp.any(move_down(board, final_shift=False)[0] != board),
-                jnp.any(move_left(board, final_shift=False)[0] != board),
+                jnp.any(move_up(board)[0] != board),
+                jnp.any(move_right(board)[0] != board),
+                jnp.any(move_down(board)[0] != board),
+                jnp.any(move_left(board)[0] != board),
             ],
         )
         return action_mask

--- a/jumanji/environments/logic/game_2048/env.py
+++ b/jumanji/environments/logic/game_2048/env.py
@@ -294,8 +294,7 @@ class Game2048(Environment[State]):
         Returns:
             action_mask: action mask for the current state of the environment.
         """
-        action_mask = jnp.array([can_move(board, action) for action in range(4)])
-        return action_mask
+        return jnp.array([can_move(board, action) for action in range(4)])
 
     def render(self, state: State) -> Optional[NDArray]:
         """Renders the current state of the game board.

--- a/jumanji/environments/logic/game_2048/env.py
+++ b/jumanji/environments/logic/game_2048/env.py
@@ -294,7 +294,7 @@ class Game2048(Environment[State]):
         Returns:
             action_mask: action mask for the current state of the environment.
         """
-        return jnp.array([can_move(board, action) for action in range(4)])
+        return jax.vmap(can_move, (None, 0))(board, jnp.arange(4))
 
     def render(self, state: State) -> Optional[NDArray]:
         """Renders the current state of the game board.

--- a/jumanji/environments/logic/game_2048/env.py
+++ b/jumanji/environments/logic/game_2048/env.py
@@ -23,13 +23,7 @@ from numpy.typing import NDArray
 from jumanji import specs
 from jumanji.env import Environment
 from jumanji.environments.logic.game_2048.types import Board, Observation, State
-from jumanji.environments.logic.game_2048.utils import (
-    move,
-    move_down,
-    move_left,
-    move_right,
-    move_up,
-)
+from jumanji.environments.logic.game_2048.utils import can_move, move
 from jumanji.environments.logic.game_2048.viewer import Game2048Viewer
 from jumanji.types import TimeStep, restart, termination, transition
 from jumanji.viewer import Viewer
@@ -300,14 +294,7 @@ class Game2048(Environment[State]):
         Returns:
             action_mask: action mask for the current state of the environment.
         """
-        action_mask = jnp.array(
-            [
-                jnp.any(move_up(board)[0] != board),
-                jnp.any(move_right(board)[0] != board),
-                jnp.any(move_down(board)[0] != board),
-                jnp.any(move_left(board)[0] != board),
-            ],
-        )
+        action_mask = jnp.array([can_move(board, action) for action in range(4)])
         return action_mask
 
     def render(self, state: State) -> Optional[NDArray]:

--- a/jumanji/environments/logic/game_2048/utils.py
+++ b/jumanji/environments/logic/game_2048/utils.py
@@ -83,9 +83,9 @@ def can_move_left_row_body(carry: CanMoveCarry) -> CanMoveCarry:
 def can_move_left_row(row: chex.Array) -> bool:
     """Check if row can move left."""
     carry = CanMoveCarry(can_move=False, row=row, target_idx=0, origin_idx=1)
-    can_move, *_ = jax.lax.while_loop(
+    can_move: bool = jax.lax.while_loop(
         can_move_left_row_cond, can_move_left_row_body, carry
-    )
+    )[0]
     return can_move
 
 

--- a/jumanji/environments/logic/game_2048/utils.py
+++ b/jumanji/environments/logic/game_2048/utils.py
@@ -202,9 +202,9 @@ def merge(carry: MoveCarry) -> MoveUpdate:
     return MoveUpdate(
         target=carry.target + 1,
         origin=0,
+        additional_reward=2.0 ** (carry.target + 1),
         target_idx=carry.target_idx + 1,
         origin_idx=carry.origin_idx + 1,
-        additional_reward=2.0 ** (carry.target + 1),
     )
 
 

--- a/jumanji/environments/logic/game_2048/utils.py
+++ b/jumanji/environments/logic/game_2048/utils.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
 from typing import Tuple
 
+import chex
 import jax
 import jax.numpy as jnp
 from jax.numpy import DeviceArray
@@ -22,128 +22,128 @@ from jax.numpy import DeviceArray
 from jumanji.environments.logic.game_2048.types import Board
 
 
-def shift_column_elements_up(carry: Tuple, i: int) -> Tuple[DeviceArray, None]:
-    """This method calls `shift_nonzero_element` to shift non-zero elements in the column,
-    and conducts the identity operation if the element is zero.
+def shift_row_elements_left(carry: Tuple, i: int) -> Tuple[DeviceArray, None]:
+    """This method shifts non-zero elements in the row, and conducts the identity operation if the
+    element is zero.
 
     Agrs:
         carry:
-            col: a one-dimensional array representing a column of the board.
+            row: a one-dimensional array representing a row of the board.
             j: the index of the non zero element. It also represents the number of non-zero
             elements that have been shifted so far.
         i: the current index.
 
     Returns:
-        A tuple containing the updated column and None.
+        A tuple containing the updated row and None.
     """
-    col, j = carry
-    new_col_j, new_j = jax.lax.cond(
-        col[i] != 0,
-        lambda col, j, i: (col[i], j + 1),
-        lambda col, j, i: (col[j], j),
-        col,
+    row, j = carry
+    new_row_j, new_j = jax.lax.cond(
+        row[i] != 0,
+        lambda row, j, i: (row[i], j + 1),
+        lambda row, j, i: (row[j], j),
+        row,
         j,
         i,
     )
-    col = col.at[j].set(new_col_j)
-    return (col, new_j), None
+    row = row.at[j].set(new_row_j)
+    return (row, new_j), None
 
 
 def fill_with_zero(carry: Tuple[DeviceArray, int]) -> Tuple[DeviceArray, int]:
-    """Fill the remaining elements of the column with zeros after shifting non-zero elements to the up.
-    For example: if the initial column is [2, 0, 2, 0] then this method will be invoked when `j`
+    """Fill the remaining elements of the row with zeros after shifting non-zero elements to the left.
+    For example: if the initial row is [2, 0, 2, 0] then this method will be invoked when `j`
     equals to 2 and 3.
 
     Args:
         carry:
-            col:  a column of the board.
+            row:  a row of the board.
             j: the index of the nonzero element. It also represents the number of nonzero
             elements that have been shifted so far.
 
     Returns:
-        A tuple containing the updated column and incremented index.
+        A tuple containing the updated row and incremented index.
     """
-    col, j = carry
-    col = col.at[j].set(0)
+    row, j = carry
+    row = row.at[j].set(0)
     j += 1
-    return col, j
+    return row, j
 
 
-def shift_up(col: DeviceArray) -> DeviceArray:
-    """Shift all the elements in a column up.
+def shift_left(row: DeviceArray) -> DeviceArray:
+    """Shift all the elements in a row left.
     For example: [2, 0, 2, 0] -> [2, 2, 0, 0]
 
     Args:
-        col: a column of the board.
+        row: a row of the board.
 
     Returns:
-        The modified column with all the elements shifted up.
+        The modified row with all the elements shifted left.
     """
     j = 0
-    (col, j), _ = jax.lax.scan(  # In example: [2, 0, 2, 0] -> [2, 2, 2, 0]
-        f=shift_column_elements_up, init=(col, j), xs=jnp.arange(len(col))
+    (row, j), _ = jax.lax.scan(  # In example: [2, 0, 2, 0] -> [2, 2, 2, 0]
+        f=shift_row_elements_left, init=(row, j), xs=jnp.arange(len(row))
     )
-    col, j = jax.lax.while_loop(  # In example: [2, 2, 2, 0] -> [2, 2, 0, 0]
-        lambda col_j: col_j[1] < len(col_j[0]),
+    row, j = jax.lax.while_loop(  # In example: [2, 2, 2, 0] -> [2, 2, 0, 0]
+        lambda row_j: row_j[1] < len(row_j[0]),
         fill_with_zero,
-        (col, j),
+        (row, j),
     )
-    return col
+    return row
 
 
 def merge_equal_elements(
     carry: Tuple[DeviceArray, float], i: int
 ) -> Tuple[Tuple[DeviceArray, float], None]:
-    """This function merges adjacent non-zero elements in the column of the board, if the
+    """This function merges adjacent non-zero elements in the row of the board, if the
     two adjacent elements are equal.
     This function will examine each element individually to locate two adjacent equal elements.
-    For example in the case of [1, 1, 2, 2], this method will call `merge_elements` for `i` equals
+    For example in the case of [1, 1, 2, 2], this method will merge elements for `i` equals
     to 0 and 2.
 
     Args:
-        carry: a tuple containing the current state of the column, and the current reward.
+        carry: a tuple containing the current state of the row, and the current reward.
         i: the current index.
 
     Returns:
-        Tuple containing the updated column and the reward.
+        Tuple containing the updated row and the reward.
     """
-    col, reward = carry
-    new_col_i, new_col_i_plus_1, additional_reward = jax.lax.cond(
-        (col[i] != 0) & (col[i] == col[i + 1]),
-        lambda col, i: (col[i] + 1, 0, 2 ** (col[i] + 1)),
-        lambda col, i: (col[i], col[i + 1], 0),
-        col,
+    row, reward = carry
+    new_row_i, new_row_i_plus_1, additional_reward = jax.lax.cond(
+        (row[i] != 0) & (row[i] == row[i + 1]),
+        lambda row, i: (row[i] + 1, 0, 2 ** (row[i] + 1)),
+        lambda row, i: (row[i], row[i + 1], 0),
+        row,
         i,
     )
-    col = col.at[i].set(new_col_i)
-    col = col.at[i + 1].set(new_col_i_plus_1)
+    row = row.at[i].set(new_row_i)
+    row = row.at[i + 1].set(new_row_i_plus_1)
     reward += additional_reward
-    return (col, reward), None
+    return (row, reward), None
 
 
-def merge_col(col: DeviceArray) -> Tuple[DeviceArray, float]:
-    """Merge the elements of a column according to the rules of the 2048 game.
+def merge_row(row: DeviceArray) -> Tuple[DeviceArray, float]:
+    """Merge the elements of a row according to the rules of the 2048 game.
     For example: [0, 0, 2, 2] -> [0, 0, 3, 0] with a reward equal to 2³.
 
     Args:
-        col: a column of the board.
+        row: a row of the board.
 
     Returns:
-        A tuple containing the modified column and the total reward obtained by
+        A tuple containing the modified row and the total reward obtained by
         merging the elements.
     """
     reward = 0.0
-    elements_indices = jnp.arange(len(col) - 1)
-    (col, reward), _ = jax.lax.scan(
-        f=merge_equal_elements, init=(col, reward), xs=elements_indices
+    elements_indices = jnp.arange(len(row) - 1)
+    (row, reward), _ = jax.lax.scan(
+        f=merge_equal_elements, init=(row, reward), xs=elements_indices
     )
-    return col, reward
+    return row, reward
 
 
-def move_up_col(
-    carry: Tuple[Board, float], c: int, final_shift: bool = True
-) -> Tuple[Tuple[Board, float], None]:
-    """Move the elements in the specified column up and merge those that are equal in
+def move_left_row(
+    row: chex.Array, final_shift: bool = True
+) -> Tuple[chex.Array, float]:
+    """Move the elements in the specified row left and merge those that are equal in
     a single pass. `final_shift` is not needed when computing the action mask - this is
     because creating the action mask only requires knowledge of whether the board will
     have changed as a result of the action.
@@ -151,35 +151,25 @@ def move_up_col(
     For example: [2, 2, 1, 1] -> [3, 2, 0, 0].
 
     Args:
-         carry: tuple containing the board and the additional reward.
-         c: column index to perform the move and merge on.
-         final_shift: is a flag to determine if the column should be shifted up once or
+         row: a row of the board.
+         final_shift: is a flag to determine if the row should be shifted left once or
          twice. In the "get_action_mask" method, it is set to False, as the purpose is
          to check if the action is allowed and one shift is enough for this determination.
 
      Returns:
          Tuple containing the updated board and the additional reward.
     """
-    board, additional_reward = carry
-    col = board[:, c]
-    col = shift_up(col)  # In example: [2, 2, 1, 1] -> [2, 2, 1, 1]
-    col, reward = merge_col(col)  # In example: [2, 2, 1, 1] -> [3, 0, 2, 0]
+    row = shift_left(row)  # In example: [2, 2, 1, 1] -> [2, 2, 1, 1]
+    row, reward = merge_row(row)  # In example: [2, 2, 1, 1] -> [3, 0, 2, 0]
     if final_shift:
-        col = shift_up(col)  # In example: [3, 0, 2, 0] -> [3, 2, 0, 0]
-    additional_reward += reward
-    return (board.at[:, c].set(col), additional_reward), None
+        row = shift_left(row)  # In example: [3, 0, 2, 0] -> [3, 2, 0, 0]
+    return row, reward
 
 
-def move_up(board: Board, final_shift: bool = True) -> Tuple[Board, float]:
-    """Move up."""
-    additional_reward = 0.0
-    col_indices = jnp.arange(board.shape[0])  # Board of size 4 -> [0, 1, 2, 3]
-    (board, additional_reward), _ = jax.lax.scan(
-        f=functools.partial(move_up_col, final_shift=final_shift),
-        init=(board, additional_reward),
-        xs=col_indices,
-    )
-    return board, additional_reward
+def move_left(board: Board, final_shift: bool = True) -> Tuple[Board, float]:
+    """Move left."""
+    board, additional_reward = jax.vmap(move_left_row, (0, None))(board, final_shift)
+    return board, additional_reward.sum()
 
 
 def transform_board(board: Board, action: int) -> Board:
@@ -187,10 +177,10 @@ def transform_board(board: Board, action: int) -> Board:
     return jax.lax.switch(
         action,
         [
-            jnp.asarray,
+            lambda board: jnp.transpose(board),
+            lambda board: jnp.flip(board, 1),
             lambda board: jnp.flip(jnp.transpose(board)),
-            jnp.flip,
-            jnp.transpose,
+            lambda board: board,
         ],
         board,
     )
@@ -199,21 +189,21 @@ def transform_board(board: Board, action: int) -> Board:
 def move(board: Board, action: int, final_shift: bool = True) -> Tuple[Board, float]:
     """Move."""
     board = transform_board(board, action)
-    board, additional_reward = move_up(board, final_shift)
+    board, additional_reward = move_left(board, final_shift)
     board = transform_board(board, action)
     return board, additional_reward
 
 
-def move_down(board: Board, final_shift: bool = True) -> Tuple[Board, float]:
-    """Move down."""
-    return move(board=board, action=2, final_shift=final_shift)
-
-
-def move_left(board: Board, final_shift: bool = True) -> Tuple[Board, float]:
-    """Move left."""
-    return move(board=board, action=3, final_shift=final_shift)
+def move_up(board: Board, final_shift: bool = True) -> Tuple[Board, float]:
+    """Move up."""
+    return move(board=board, action=0, final_shift=final_shift)
 
 
 def move_right(board: Board, final_shift: bool = True) -> Tuple[Board, float]:
     """Move right."""
     return move(board=board, action=1, final_shift=final_shift)
+
+
+def move_down(board: Board, final_shift: bool = True) -> Tuple[Board, float]:
+    """Move down."""
+    return move(board=board, action=2, final_shift=final_shift)

--- a/jumanji/environments/logic/game_2048/utils.py
+++ b/jumanji/environments/logic/game_2048/utils.py
@@ -12,155 +12,129 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
+from typing import NamedTuple, Tuple
 
 import chex
 import jax
 import jax.numpy as jnp
-from jax.numpy import DeviceArray
 
 from jumanji.environments.logic.game_2048.types import Board
 
 
-def shift_row_elements_left(origin: int, carry: Tuple) -> Tuple[DeviceArray, int]:
-    """This method shifts non-zero elements in the row, and conducts the identity operation if the
-    element is zero.
+class MoveUpdate(NamedTuple):
+    """Update to move carry."""
 
-    Agrs:
-        origin: the index to shift from.
-        carry:
-            row: a one-dimensional array representing a row of the board.
-            target: the index to shift from. It also represents the number of non-zero elements
-            that have been shifted so far.
+    target: chex.Numeric
+    origin: chex.Numeric
+    additional_reward: float
+    target_idx: int
+    origin_idx: int
 
-    Returns:
-        A tuple containing the updated row and the new target.
-    """
-    row, target = carry
-    new_row_target, new_target = jax.lax.cond(
-        row[origin] != 0,
-        lambda row, target, origin: (row[origin], target + 1),
-        lambda row, target, origin: (row[target], target),
-        row,
-        target,
-        origin,
+
+class MoveCarry(NamedTuple):
+    """Carry value for while loop in move_left_row."""
+
+    row: chex.Array
+    reward: float
+    target_idx: int
+    origin_idx: int
+
+    @property
+    def target(self) -> chex.Numeric:
+        """Tile at target index of row."""
+        return self.row[self.target_idx]
+
+    @property
+    def origin(self) -> chex.Numeric:
+        """Tile at origin index of row."""
+        return self.row[self.origin_idx]
+
+    def update(self, update: MoveUpdate) -> "MoveCarry":
+        """Return new updated carry. This method should not be called from within a jax.lax.cond."""
+        row = self.row
+        row = row.at[self.target_idx].set(update.target)
+        row = row.at[self.origin_idx].set(update.origin)
+        return self._replace(
+            row=row,
+            reward=self.reward + update.additional_reward,
+            target_idx=update.target_idx,
+            origin_idx=update.origin_idx,
+        )
+
+
+def no_op(carry: MoveCarry) -> MoveUpdate:
+    """Returns a move update equivalent to performing a no op."""
+    target_idx = jax.lax.cond(
+        carry.origin == 0,
+        lambda: carry.target_idx,
+        lambda: carry.target_idx + 1,
     )
-    row = row.at[target].set(new_row_target)
-    return row, new_target
-
-
-def fill_with_zero(target: int, row: chex.Array) -> chex.Array:
-    """Fill the remaining elements of the row with zeros after shifting non-zero elements to the left.
-    For example: if the initial row is [2, 0, 2, 0] then this method will be invoked when `target`
-    equals to 2 and 3.
-
-    Args:
-        target: index to fill with 0.
-        row: a one-dimensional array representing a row of the board.
-
-    Returns:
-        The updated row.
-    """
-    row = row.at[target].set(0)
-    return row
-
-
-def shift_left(row: DeviceArray) -> DeviceArray:
-    """Shift all the elements in a row left.
-    For example: [2, 0, 2, 0] -> [2, 2, 0, 0]
-
-    Args:
-        row: a one-dimensional array representing a row of the board.
-
-    Returns:
-        The modified row with all the elements shifted left.
-    """
-    target = 0
-    row, target = jax.lax.fori_loop(
-        0, row.shape[0], shift_row_elements_left, (row, target)
+    origin_idx = jax.lax.cond(
+        (carry.origin == 0) | (target_idx == carry.origin_idx),
+        lambda: carry.origin_idx + 1,
+        lambda: carry.origin_idx,
     )
-    row = jax.lax.fori_loop(target, row.shape[0], fill_with_zero, row)
-    return row
-
-
-def merge_equal_elements(
-    target: int, carry: Tuple[DeviceArray, float]
-) -> Tuple[DeviceArray, float]:
-    """This function merges adjacent non-zero elements in the row of the board, if the
-    two adjacent elements are equal.
-    This function will examine each element individually to locate two adjacent equal elements.
-    For example in the case of [1, 1, 2, 2], this method will merge elements for `target` equals
-    to 0 and 2.
-
-    Args:
-        target: index to merge into.
-        carry: a tuple containing the current state of the row and the current reward.
-
-    Returns:
-        Tuple containing the updated row and the reward.
-    """
-    row, reward = carry
-    new_row_target, new_row_target_plus_1, additional_reward = jax.lax.cond(
-        (row[target] != 0) & (row[target] == row[target + 1]),
-        lambda row, target: (row[target] + 1, 0, 2 ** (row[target] + 1)),
-        lambda row, target: (row[target], row[target + 1], 0),
-        row,
-        target,
+    return MoveUpdate(
+        target=carry.target,
+        origin=carry.origin,
+        additional_reward=0.0,
+        target_idx=target_idx,
+        origin_idx=origin_idx,
     )
-    row = row.at[target].set(new_row_target)
-    row = row.at[target + 1].set(new_row_target_plus_1)
-    reward += additional_reward
+
+
+def shift(carry: MoveCarry) -> MoveUpdate:
+    """Returns a move update equivalent to shifting origin to target."""
+    return MoveUpdate(
+        target=carry.origin,
+        origin=0,
+        additional_reward=0.0,
+        target_idx=carry.target_idx,
+        origin_idx=carry.origin_idx + 1,
+    )
+
+
+def merge(carry: MoveCarry) -> MoveUpdate:
+    """Returns a move update equivalent to merging origin with target."""
+    return MoveUpdate(
+        target=carry.target + 1,
+        origin=0,
+        target_idx=carry.target_idx + 1,
+        origin_idx=carry.origin_idx + 1,
+        additional_reward=2.0 ** (carry.target + 1),
+    )
+
+
+def move_left_row_cond(carry: MoveCarry) -> chex.Numeric:
+    """Terminates loop when origin reaches end of row."""
+    return carry.origin_idx < carry.row.shape[0]
+
+
+def move_left_row_body(carry: MoveCarry) -> MoveCarry:
+    """Returns new carry after performing appropiate op."""
+    can_shift = (carry.origin != 0) & (carry.target == 0)
+    can_merge = (carry.origin != 0) & (carry.target == carry.origin)
+    move_type = can_shift.astype(int) + 2 * can_merge.astype(int)
+    update = jax.lax.switch(move_type, [no_op, shift, merge], carry)
+    return carry.update(update)
+
+
+def move_left_row(row: chex.Array) -> Tuple[chex.Array, float]:
+    """Move the elements in the row left."""
+    carry = MoveCarry(
+        row=row,
+        reward=0.0,
+        target_idx=0,
+        origin_idx=1,
+    )
+    row, reward = jax.lax.while_loop(move_left_row_cond, move_left_row_body, carry)[:2]
     return row, reward
 
 
-def merge_row(row: DeviceArray) -> Tuple[DeviceArray, float]:
-    """Merge the elements of a row according to the rules of the 2048 game.
-    For example: [0, 0, 2, 2] -> [0, 0, 3, 0] with a reward equal to 2³.
-
-    Args:
-        row: a one-dimensional array representing a row of the board.
-
-    Returns:
-        A tuple containing the modified row and the total reward obtained by
-        merging the elements.
-    """
-    reward = 0.0
-    row, reward = jax.lax.fori_loop(
-        0, row.shape[0] - 1, merge_equal_elements, (row, reward)
-    )
-    return row, reward
-
-
-def move_left_row(
-    row: chex.Array, final_shift: bool = True
-) -> Tuple[chex.Array, float]:
-    """Move the elements in the specified row left and merge those that are equal in
-    a single pass. `final_shift` is not needed when computing the action mask - this is
-    because creating the action mask only requires knowledge of whether the board will
-    have changed as a result of the action.
-
-    For example: [2, 2, 1, 1] -> [3, 2, 0, 0].
-
-    Args:
-         row: a one-dimensional array representing a row of the board.
-         final_shift: is a flag to determine if the row should be shifted left once or
-         twice. In the "get_action_mask" method, it is set to False, as the purpose is
-         to check if the action is allowed and one shift is enough for this determination.
-
-     Returns:
-         Tuple containing the updated board and the additional reward.
-    """
-    row = shift_left(row)  # In example: [2, 2, 1, 1] -> [2, 2, 1, 1]
-    row, reward = merge_row(row)  # In example: [2, 2, 1, 1] -> [3, 0, 2, 0]
-    if final_shift:
-        row = shift_left(row)  # In example: [3, 0, 2, 0] -> [3, 2, 0, 0]
-    return row, reward
-
-
-def move_left(board: Board, final_shift: bool = True) -> Tuple[Board, float]:
+def move_left(board: Board) -> Tuple[Board, float]:
     """Move left."""
-    board, additional_reward = jax.vmap(move_left_row, (0, None))(board, final_shift)
-    return board, additional_reward.sum()
+    board, reward = jax.vmap(move_left_row)(board)
+    return board, reward.sum()
 
 
 def transform_board(board: Board, action: int) -> Board:
@@ -177,24 +151,24 @@ def transform_board(board: Board, action: int) -> Board:
     )
 
 
-def move(board: Board, action: int, final_shift: bool = True) -> Tuple[Board, float]:
+def move(board: Board, action: int) -> Tuple[Board, float]:
     """Move."""
     board = transform_board(board, action)
-    board, additional_reward = move_left(board, final_shift)
+    board, reward = move_left(board)
     board = transform_board(board, action)
-    return board, additional_reward
+    return board, reward
 
 
-def move_up(board: Board, final_shift: bool = True) -> Tuple[Board, float]:
+def move_up(board: Board) -> Tuple[Board, float]:
     """Move up."""
-    return move(board=board, action=0, final_shift=final_shift)
+    return move(board=board, action=0)
 
 
-def move_right(board: Board, final_shift: bool = True) -> Tuple[Board, float]:
+def move_right(board: Board) -> Tuple[Board, float]:
     """Move right."""
-    return move(board=board, action=1, final_shift=final_shift)
+    return move(board=board, action=1)
 
 
-def move_down(board: Board, final_shift: bool = True) -> Tuple[Board, float]:
+def move_down(board: Board) -> Tuple[Board, float]:
     """Move down."""
-    return move(board=board, action=2, final_shift=final_shift)
+    return move(board=board, action=2)

--- a/jumanji/environments/logic/game_2048/utils.py
+++ b/jumanji/environments/logic/game_2048/utils.py
@@ -216,25 +216,38 @@ def move_up(board: Board, final_shift: bool = True) -> Tuple[Board, float]:
     return board, additional_reward
 
 
+def transform_board(board: Board, action: int) -> Board:
+    """Transform board."""
+    return jax.lax.switch(
+        action,
+        [
+            jnp.asarray,
+            lambda board: jnp.flip(jnp.transpose(board)),
+            jnp.flip,
+            jnp.transpose,
+        ],
+        board,
+    )
+
+
+def move(board: Board, action: int, final_shift: bool = True) -> Tuple[Board, float]:
+    """Move."""
+    board = transform_board(board, action)
+    board, additional_reward = move_up(board, final_shift)
+    board = transform_board(board, action)
+    return board, additional_reward
+
+
 def move_down(board: Board, final_shift: bool = True) -> Tuple[Board, float]:
     """Move down."""
-    board, additional_reward = move_up(
-        board=jnp.flip(board, 0), final_shift=final_shift
-    )
-    return jnp.flip(board, 0), additional_reward
+    return move(board=board, action=2, final_shift=final_shift)
 
 
 def move_left(board: Board, final_shift: bool = True) -> Tuple[Board, float]:
     """Move left."""
-    board, additional_reward = move_up(
-        board=jnp.rot90(board, k=-1), final_shift=final_shift
-    )
-    return jnp.rot90(board, k=1), additional_reward
+    return move(board=board, action=3, final_shift=final_shift)
 
 
 def move_right(board: Board, final_shift: bool = True) -> Tuple[Board, float]:
     """Move right."""
-    board, additional_reward = move_up(
-        board=jnp.rot90(board, k=1), final_shift=final_shift
-    )
-    return jnp.rot90(board, k=-1), additional_reward
+    return move(board=board, action=1, final_shift=final_shift)

--- a/jumanji/environments/logic/game_2048/utils.py
+++ b/jumanji/environments/logic/game_2048/utils.py
@@ -26,12 +26,11 @@ def transform_board(board: Board, action: int) -> Board:
     return jax.lax.switch(
         action,
         [
-            lambda board: jnp.transpose(board),
-            lambda board: jnp.flip(board, 1),
-            lambda board: jnp.flip(jnp.transpose(board)),
-            lambda board: board,
+            lambda: jnp.transpose(board),
+            lambda: jnp.flip(board, 1),
+            lambda: jnp.flip(jnp.transpose(board)),
+            lambda: board,
         ],
-        board,
     )
 
 

--- a/jumanji/environments/logic/game_2048/utils_test.py
+++ b/jumanji/environments/logic/game_2048/utils_test.py
@@ -17,6 +17,10 @@ import pytest
 
 from jumanji.environments.logic.game_2048.types import Board
 from jumanji.environments.logic.game_2048.utils import (
+    can_move_down,
+    can_move_left,
+    can_move_right,
+    can_move_up,
     move_down,
     move_left,
     move_right,
@@ -70,6 +74,38 @@ def board8x8() -> Board:
         ]
     )
     return board
+
+
+def test_can_move_down(board: Board, another_board: Board) -> None:
+    """Test checking if the board can move down."""
+    assert can_move_down(board)
+    assert can_move_down(another_board)
+    board = jnp.array([[0, 0, 0, 0], [1, 0, 0, 0], [2, 1, 0, 0], [3, 2, 1, 0]])
+    assert ~can_move_down(board)
+
+
+def test_can_move_up(board: Board, another_board: Board) -> None:
+    """Test checking if the board can move up."""
+    assert can_move_up(board)
+    assert can_move_up(another_board)
+    board = jnp.array([[4, 2, 1, 0], [3, 1, 0, 0], [2, 0, 0, 0], [1, 0, 0, 0]])
+    assert ~can_move_up(board)
+
+
+def test_can_move_right(board: Board, another_board: Board) -> None:
+    """Test checking if the board can move right."""
+    assert can_move_right(board)
+    assert can_move_right(another_board)
+    board = jnp.array([[0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 2], [0, 1, 2, 3]])
+    assert ~can_move_right(board)
+
+
+def test_can_move_left(board: Board, another_board: Board) -> None:
+    """Test checking if the board can move left."""
+    assert can_move_left(board)
+    assert can_move_left(another_board)
+    board = jnp.array([[1, 2, 3, 4], [1, 2, 0, 0], [1, 0, 0, 0], [0, 0, 0, 0]])
+    assert ~can_move_left(board)
 
 
 def test_move_down(board: Board, another_board: Board) -> None:


### PR DESCRIPTION
This PR improves the performance of the Game2048 environment. The improvements include

- Minimizing logic inside of `jax.lax.cond` and `jax.lax.switch`
- Using `jax.vmap` over `jax.lax.scan` where possible
- A new move implementation
- A can_move implementation that validates an action without mutating the board

|      | no vmap | vmap 10<sup>3</sup> | vmap 10<sup>6</sup> |
|:-----|-:|-:|-:|
| cpu  | 64.36%  | 201.80%  | 392.29% |
| cuda | 900.12% | 1923.08% | 706.87% |

The above figure shows the total performance improvement measured as percent increase in steps/sec. For more detailed benchmarking, see [here](https://github.com/aar65537/jumanji-benchmarks).