### PR TITLE
fix: reward and discount spec not in wrapper

### DIFF
--- a/jumanji/wrappers.py
+++ b/jumanji/wrappers.py
@@ -96,6 +96,14 @@ class Wrapper(Environment[State], Generic[State]):
         """Returns the action spec."""
         return self._env.action_spec()
 
+    def reward_spec(self) -> specs.Array:
+        """Returns the reward spec."""
+        return self._env.reward_spec()
+
+    def discount_spec(self) -> specs.Array:
+        """Returns the discount spec."""
+        return self._env.discount_spec()
+
     def render(self, state: State) -> Any:
         """Compute render frames during initialisation of the environment.
 

--- a/jumanji/wrappers.py
+++ b/jumanji/wrappers.py
@@ -100,7 +100,7 @@ class Wrapper(Environment[State], Generic[State]):
         """Returns the reward spec."""
         return self._env.reward_spec()
 
-    def discount_spec(self) -> specs.Array:
+    def discount_spec(self) -> specs.BoundedArray:
         """Returns the discount spec."""
         return self._env.discount_spec()
 


### PR DESCRIPTION
The `reward_spec` and `discount_spec` methods are not in `Wrapper`. As such when wrapping an environment with a reward/discount spec that is not the default (`shape=()`), the reward and discount specs are set to the default unless they are specified again in the wrapper.

For example
```python
class MyWrapper(Wrapper):
    def reset(self, key):
        do_some_stuff()
        return self._env.reset(key)

env = Connector()
wrapped = MyWrapper(env)

env.reward_spec() == wrapped.reward_spec()  # <-- false
```