### PR TITLE
fix: timestep extras default value

### DIFF
--- a/jumanji/types.py
+++ b/jumanji/types.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import field
 from typing import TYPE_CHECKING, Dict, Generic, Optional, Sequence, TypeVar, Union
 
 if TYPE_CHECKING:  # https://github.com/python/mypy/issues/6239
@@ -71,14 +72,14 @@ class TimeStep(Generic[Observation]):
         extras: environment metric(s) or information returned by the environment but
             not observed by the agent (hence not in the observation). For example, it
             could be whether an invalid action was taken. In most environments, extras
-            is None.
+            is an empty dictionary.
     """
 
     step_type: StepType
     reward: Array
     discount: Array
     observation: Observation
-    extras: Optional[Dict] = None
+    extras: Dict = field(default_factory=dict)
 
     def first(self) -> Array:
         return self.step_type == StepType.FIRST

--- a/jumanji/types.py
+++ b/jumanji/types.py
@@ -111,6 +111,7 @@ def restart(
     Returns:
         TimeStep identified as a reset.
     """
+    extras = extras or {}
     return TimeStep(
         step_type=StepType.FIRST,
         reward=jnp.zeros(shape, dtype=float),
@@ -145,6 +146,7 @@ def transition(
         TimeStep identified as a transition.
     """
     discount = discount if discount is not None else jnp.ones(shape, dtype=float)
+    extras = extras or {}
     return TimeStep(
         step_type=StepType.MID,
         reward=reward,
@@ -176,6 +178,7 @@ def termination(
     Returns:
         TimeStep identified as the termination of an episode.
     """
+    extras = extras or {}
     return TimeStep(
         step_type=StepType.LAST,
         reward=reward,
@@ -209,6 +212,7 @@ def truncation(
         TimeStep identified as the truncation of an episode.
     """
     discount = discount if discount is not None else jnp.ones(shape, dtype=float)
+    extras = extras or {}
     return TimeStep(
         step_type=StepType.LAST,
         reward=reward,


### PR DESCRIPTION
`timestep.extras` defaults to `None` and there are certain cases where this doesn't work. For example when making a wrapper and you want to add items to extras. The issue is that you don't know if the dictionary is initialized by the env or another wrapper, so you need to do something like `timestep.extras = timestep.extras or None` or `jax.lax.cond(timestep.extras is None, {}, timestep.extras)`. However both these approaches don't work in jax - first one is a concretization error and in the second the `true_fun` and `false_fun` don't have the same type structure.

If we default the extras field to `{}` then one can simply do `timestep.extras[key] = value` which solves the initialization issue.