### PR TITLE
fix: autoreset wrappers

### DIFF
--- a/jumanji/wrappers.py
+++ b/jumanji/wrappers.py
@@ -360,13 +360,13 @@ class VmapWrapper(Wrapper):
         return super().render(state_0)
 
 
-OBS_IN_EXTRAS_KEY = "real_next_obs"
+NEXT_OBS_KEY_IN_EXTRAS = "next_obs"
 
 
 def _obs_in_extras(
     state: State, timestep: TimeStep[Observation]
 ) -> Tuple[State, TimeStep[Observation]]:
-    """Place the observation in timestep.extras[OBS_IN_EXTRAS_KEY].
+    """Place the observation in timestep.extras[NEXT_OBS_KEY_IN_EXTRAS].
     Used when auto-resetting to store the observation from the terminal TimeStep.
 
     Args:
@@ -374,10 +374,10 @@ def _obs_in_extras(
         timestep: TimeStep object containing the timestep returned by the environment.
 
     Returns:
-        (state, timestep): where the observation is placed in timestep.extras[OBS_IN_EXTRAS_KEY].
+        (state, timestep): where the observation is placed in timestep.extras["next_obs"].
     """
     extras = timestep.extras
-    extras[OBS_IN_EXTRAS_KEY] = timestep.observation
+    extras[NEXT_OBS_KEY_IN_EXTRAS] = timestep.observation
     return state, timestep.replace(extras=extras)  # type: ignore
 
 
@@ -386,7 +386,7 @@ class AutoResetWrapper(Wrapper):
     the state, observation, and step_type are reset. The observation and step_type of the
     terminal TimeStep is reset to the reset observation and StepType.LAST, respectively.
     The reward, discount, and extras retrieved from the transition to the terminal state.
-    NOTE: The observation from the terminal TimeStep is stored in timestep.extras["real_next_obs"].
+    NOTE: The observation from the terminal TimeStep is stored in timestep.extras["next_obs"].
     WARNING: do not `jax.vmap` the wrapped environment (e.g. do not use with the `VmapWrapper`),
     which would lead to inefficient computation due to both the `step` and `reset` functions
     being processed each time `step` is called. Please use the `VmapAutoResetWrapper` instead.
@@ -447,7 +447,7 @@ class VmapAutoResetWrapper(Wrapper):
     - Homogeneous computation: call step function on all environments in the batch.
     - Heterogeneous computation: conditional auto-reset (call reset function for some environments
         within the batch because they have terminated).
-    NOTE: The observation from the terminal TimeStep is stored in timestep.extras["real_next_obs"].
+    NOTE: The observation from the terminal TimeStep is stored in timestep.extras["next_obs"].
     """
 
     def reset(self, key: chex.PRNGKey) -> Tuple[State, TimeStep[Observation]]:


### PR DESCRIPTION
There was an issue with the autoreset wrappers: they never showed you the final timestep. This is an issue if the final timestep is a truncation (discount = 1, timestep.last() = true), then we'd want this observation in order to get the next value for our value target, but currently this would not be possible.

Gym fixes does it in the same way I am proposing as can be seen [here](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/dqn.py#L195) they place the final observation in infos. What this PR does is always place either the current observation or the terminal observation in `timestep.extras["real_next_obs"]`

Here's how I'm currently using for SAC (and it's working well there):
```
    def step(
        action: Array, obs: Observation, env_state: State, buffer_state: BufferState
    ) -> Tuple[Array, State, BufferState, Dict]:
        """Given an action, step the environment and add to the buffer."""
        env_state, timestep = jax.vmap(env.step)(env_state, action)
        next_obs = timestep.observation
        rewards = timestep.reward
        terms = ~(timestep.discount).astype(bool)
        infos = timestep.extras

        real_next_obs = infos["real_next_obs"]

        transition = Transition(obs, action, rewards, terms, real_next_obs)
        buffer_state = rb.add(buffer_state, transition)

        return next_obs, env_state, buffer_state, infos["episode_metrics"]
```