### PR TITLE
fix: requirements

### DIFF
--- a/requirements/requirements-train.txt
+++ b/requirements/requirements-train.txt
@@ -1,5 +1,4 @@
 dm-haiku==0.0.9
-huggingface-hub
 hydra-core==1.3
 neptune-client==0.16.15
 optax>=0.1.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,7 @@
 chex>=0.1.3
 dm-env>=1.5
 gym>=0.22.0
+huggingface-hub
 jax>=0.2.26
 matplotlib~=3.7.4
 numpy>=1.19.5


### PR DESCRIPTION
Sokoban introduced huggingface-hub as a requirement. It's only in requirements-train, but it's need to run jumanji, so moving it to the main requirements