### PR TITLE
Fix/packages data not included in sokoban

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include requirements/*
 recursive-include * *.npy
+recursive-include jumanji *.png
 
 # remove the test specific files
 recursive-exclude * *_test.py

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         "dev": _parse_requirements("requirements/requirements-dev.txt"),
         "train": _parse_requirements("requirements/requirements-train.txt"),
     },
-    package_data={"jumanji": ["py.typed", "*.png"]},
+    package_data={"jumanji": ["py.typed", "**.png"]},
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         "dev": _parse_requirements("requirements/requirements-dev.txt"),
         "train": _parse_requirements("requirements/requirements-train.txt"),
     },
-    package_data={"jumanji": ["py.typed", "**.png"]},
+    package_data={"jumanji": ["py.typed"]},
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         "dev": _parse_requirements("requirements/requirements-dev.txt"),
         "train": _parse_requirements("requirements/requirements-train.txt"),
     },
-    package_data={"jumanji": ["py.typed"]},
+    package_data={"jumanji": ["py.typed", "*.png"]},
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",


### PR DESCRIPTION
Fixes #226.

I included it in the MANIFEST.in, not sure if there is a policy in the repo to use the `package_data` in setup.py instead. 