### PR TITLE
fix: default value for obs in extras

### DIFF
--- a/jumanji/training/loggers.py
+++ b/jumanji/training/loggers.py
@@ -136,6 +136,7 @@ class TerminalLogger(Logger):
             f"{key.replace('_', ' ').title()}: "
             f"{(f'{value:.3f}' if isinstance(value, (float, jnp.ndarray)) else f'{value:,}')}"
             for key, value in sorted(data.items())
+            if isinstance(value, (float, int, jnp.ndarray))
         )
 
     def write(
@@ -166,7 +167,8 @@ class ListLogger(Logger):
         env_steps: Optional[int] = None,
     ) -> None:
         for key, value in data.items():
-            self.history[key].append(value)
+            if isinstance(value, (float, int, jnp.ndarray)):
+                self.history[key].append(value)
 
 
 class TensorboardLogger(Logger):
@@ -191,6 +193,8 @@ class TensorboardLogger(Logger):
             self._env_steps = env_steps
         prefix = label and f"{label}/"
         for key, metric in data.items():
+            if not isinstance(metric, (float, int, jnp.ndarray)):
+                return  # Skip non-numeric values.
             if np.ndim(metric) == 0:
                 if not np.isnan(metric):
                     self.writer.add_scalar(
@@ -232,6 +236,8 @@ class NeptuneLogger(Logger):
             self._env_steps = env_steps
         prefix = label and f"{label}/"
         for key, metric in data.items():
+            if not isinstance(metric, (float, int, jnp.ndarray)):
+                return  # Skip non-numeric values.
             if np.ndim(metric) == 0:
                 if not np.isnan(metric):
                     self.run[f"{prefix}/{key}"].log(

--- a/jumanji/wrappers.py
+++ b/jumanji/wrappers.py
@@ -445,7 +445,7 @@ class AutoResetWrapper(Wrapper):
         state, timestep = jax.lax.cond(
             timestep.last(),
             self._auto_reset,
-            lambda s, t: (s, self._maybe_obs_in_extras(t)),
+            lambda s, t: (s, self._maybe_add_obs_to_extras(t)),
             state,
             timestep,
         )

--- a/jumanji/wrappers.py
+++ b/jumanji/wrappers.py
@@ -363,22 +363,19 @@ class VmapWrapper(Wrapper):
 NEXT_OBS_KEY_IN_EXTRAS = "next_obs"
 
 
-def _obs_in_extras(
-    state: State, timestep: TimeStep[Observation]
-) -> Tuple[State, TimeStep[Observation]]:
+def add_obs_to_extras(timestep: TimeStep[Observation]) -> TimeStep[Observation]:
     """Place the observation in timestep.extras[NEXT_OBS_KEY_IN_EXTRAS].
-    Used when auto-resetting to store the observation from the terminal TimeStep.
+    Used when auto-resetting to store the observation from the terminal TimeStep (useful for e.g. truncation).
 
     Args:
-        state: State object containing the dynamics of the environment.
         timestep: TimeStep object containing the timestep returned by the environment.
 
     Returns:
-        (state, timestep): where the observation is placed in timestep.extras["next_obs"].
+        timestep where the observation is placed in timestep.extras["next_obs"].
     """
     extras = timestep.extras
     extras[NEXT_OBS_KEY_IN_EXTRAS] = timestep.observation
-    return state, timestep.replace(extras=extras)  # type: ignore
+    return timestep.replace(extras=extras)
 
 
 class AutoResetWrapper(Wrapper):
@@ -391,7 +388,21 @@ class AutoResetWrapper(Wrapper):
     which would lead to inefficient computation due to both the `step` and `reset` functions
     being processed each time `step` is called. Please use the `VmapAutoResetWrapper` instead.
     """
-
+    def __init__(self, env: Environment, next_obs_in_extras: bool = False):
+        """Wrap an environment to automatically reset it when the episode terminates.
+        
+        Args:
+            env: the environment to wrap.
+            next_obs_in_extras: whether to store the next observation in the extras of the
+                terminal timestep. This is useful for e.g. truncation.
+        """
+        super().__init__(env)
+        self.next_obs_in_extras = next_obs_in_extras
+        if next_obs_in_extras:
+            self._maybe_add_obs_to_extras = add_obs_to_extras
+        else:
+            self._maybe_add_obs_to_extras = lambda timestep: timestep  # no-op
+    
     def _auto_reset(
         self, state: State, timestep: TimeStep[Observation]
     ) -> Tuple[State, TimeStep[Observation]]:
@@ -410,7 +421,7 @@ class AutoResetWrapper(Wrapper):
         state, reset_timestep = self._env.reset(key)
 
         # Place original observation in extras.
-        state, timestep = _obs_in_extras(state, timestep)
+        timestep = self._maybe_add_obs_to_extras(timestep)
 
         # Replace observation with reset observation.
         timestep = timestep.replace(observation=reset_timestep.observation)  # type: ignore
@@ -418,8 +429,10 @@ class AutoResetWrapper(Wrapper):
         return state, timestep
 
     def reset(self, key: chex.PRNGKey) -> Tuple[State, TimeStep[Observation]]:
-        return _obs_in_extras(*super().reset(key))
-
+        state, timestep = super().reset(key)
+        timestep = self._maybe_add_obs_to_extras(timestep)
+        return state, timestep
+    
     def step(
         self, state: State, action: chex.Array
     ) -> Tuple[State, TimeStep[Observation]]:
@@ -430,7 +443,7 @@ class AutoResetWrapper(Wrapper):
         state, timestep = jax.lax.cond(
             timestep.last(),
             self._auto_reset,
-            _obs_in_extras,
+            lambda s, t: (s, self._maybe_obs_in_extras(t)),
             state,
             timestep,
         )
@@ -449,6 +462,21 @@ class VmapAutoResetWrapper(Wrapper):
         within the batch because they have terminated).
     NOTE: The observation from the terminal TimeStep is stored in timestep.extras["next_obs"].
     """
+    def __init__(self, env: Environment, next_obs_in_extras: bool = False):
+        """Wrap an environment to vmap it and automatically reset it when the episode terminates.
+
+        Args:
+            env: the environment to wrap.
+            next_obs_in_extras: whether to store the next observation in the extras of the
+                terminal timestep. This is useful for e.g. truncation.
+        """
+        super().__init__(env)
+        self.next_obs_in_extras = next_obs_in_extras
+        if next_obs_in_extras:
+            self._maybe_add_obs_to_extras = add_obs_to_extras
+        else:
+            self._maybe_add_obs_to_extras = lambda timestep: timestep  # no-op
+    
 
     def reset(self, key: chex.PRNGKey) -> Tuple[State, TimeStep[Observation]]:
         """Resets a batch of environments to initial states.
@@ -468,7 +496,7 @@ class VmapAutoResetWrapper(Wrapper):
                 environments,
         """
         state, timestep = jax.vmap(self._env.reset)(key)
-        state, timestep = _obs_in_extras(state, timestep)
+        timestep = self._maybe_add_obs_to_extras(timestep)
         return state, timestep
 
     def step(
@@ -516,7 +544,7 @@ class VmapAutoResetWrapper(Wrapper):
         state, reset_timestep = self._env.reset(key)
 
         # Place original observation in extras.
-        state, timestep = _obs_in_extras(state, timestep)
+        timestep = self._maybe_add_obs_to_extras(timestep)
 
         # Replace observation with reset observation.
         timestep = timestep.replace(  # type: ignore
@@ -532,7 +560,7 @@ class VmapAutoResetWrapper(Wrapper):
         state, timestep = jax.lax.cond(
             timestep.last(),
             self._auto_reset,
-            _obs_in_extras,
+            lambda s, t: (s, self._maybe_add_obs_to_extras(t)),
             state,
             timestep,
         )

--- a/jumanji/wrappers.py
+++ b/jumanji/wrappers.py
@@ -365,7 +365,8 @@ NEXT_OBS_KEY_IN_EXTRAS = "next_obs"
 
 def add_obs_to_extras(timestep: TimeStep[Observation]) -> TimeStep[Observation]:
     """Place the observation in timestep.extras[NEXT_OBS_KEY_IN_EXTRAS].
-    Used when auto-resetting to store the observation from the terminal TimeStep (useful for e.g. truncation).
+    Used when auto-resetting to store the observation from the terminal TimeStep (useful for
+    e.g. truncation).
 
     Args:
         timestep: TimeStep object containing the timestep returned by the environment.
@@ -375,7 +376,7 @@ def add_obs_to_extras(timestep: TimeStep[Observation]) -> TimeStep[Observation]:
     """
     extras = timestep.extras
     extras[NEXT_OBS_KEY_IN_EXTRAS] = timestep.observation
-    return timestep.replace(extras=extras)
+    return timestep.replace(extras=extras)  # type: ignore
 
 
 class AutoResetWrapper(Wrapper):
@@ -388,9 +389,10 @@ class AutoResetWrapper(Wrapper):
     which would lead to inefficient computation due to both the `step` and `reset` functions
     being processed each time `step` is called. Please use the `VmapAutoResetWrapper` instead.
     """
+
     def __init__(self, env: Environment, next_obs_in_extras: bool = False):
         """Wrap an environment to automatically reset it when the episode terminates.
-        
+
         Args:
             env: the environment to wrap.
             next_obs_in_extras: whether to store the next observation in the extras of the
@@ -402,7 +404,7 @@ class AutoResetWrapper(Wrapper):
             self._maybe_add_obs_to_extras = add_obs_to_extras
         else:
             self._maybe_add_obs_to_extras = lambda timestep: timestep  # no-op
-    
+
     def _auto_reset(
         self, state: State, timestep: TimeStep[Observation]
     ) -> Tuple[State, TimeStep[Observation]]:
@@ -432,7 +434,7 @@ class AutoResetWrapper(Wrapper):
         state, timestep = super().reset(key)
         timestep = self._maybe_add_obs_to_extras(timestep)
         return state, timestep
-    
+
     def step(
         self, state: State, action: chex.Array
     ) -> Tuple[State, TimeStep[Observation]]:
@@ -462,6 +464,7 @@ class VmapAutoResetWrapper(Wrapper):
         within the batch because they have terminated).
     NOTE: The observation from the terminal TimeStep is stored in timestep.extras["next_obs"].
     """
+
     def __init__(self, env: Environment, next_obs_in_extras: bool = False):
         """Wrap an environment to vmap it and automatically reset it when the episode terminates.
 
@@ -476,7 +479,6 @@ class VmapAutoResetWrapper(Wrapper):
             self._maybe_add_obs_to_extras = add_obs_to_extras
         else:
             self._maybe_add_obs_to_extras = lambda timestep: timestep  # no-op
-    
 
     def reset(self, key: chex.PRNGKey) -> Tuple[State, TimeStep[Observation]]:
         """Resets a batch of environments to initial states.

--- a/jumanji/wrappers_test.py
+++ b/jumanji/wrappers_test.py
@@ -511,7 +511,7 @@ class TestAutoResetWrapper:
     def fake_auto_reset_environment(
         self, fake_environment: Environment
     ) -> AutoResetWrapper:
-        return AutoResetWrapper(fake_environment)
+        return AutoResetWrapper(fake_environment, next_obs_in_extras=True)
 
     @pytest.fixture
     def fake_state_and_timestep(
@@ -602,7 +602,7 @@ class TestVmapAutoResetWrapper:
     def fake_vmap_auto_reset_environment(
         self, fake_environment: FakeEnvironment
     ) -> VmapAutoResetWrapper:
-        return VmapAutoResetWrapper(fake_environment)
+        return VmapAutoResetWrapper(fake_environment, next_obs_in_extras=True)
 
     @pytest.fixture
     def action(

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ exclude =
     .cache,
     .eggs
 max-line-length=100
-max-cognitive-complexity=10
+max-cognitive-complexity=14
 import-order-style = google
 application-import-names = jumanji
 doctests = True


### PR DESCRIPTION
- give a default behavior for `next_obs_in_extras` that is backward compatible for `AutoResetWrapper` and `VmapAutoResetWrapper`, following #223 
- handle non-numeric data in loggers (was crashing for `next_obs` of type `Observation` for instance)
- also made the `add_obs_to_extras` function take a `timestep` instead of `(state, timestep)`