### PR TITLE
fix: remove num agents from cleaner init in docs

### DIFF
--- a/docs/api/environments/cleaner.md
+++ b/docs/api/environments/cleaner.md
@@ -1,1 +1,9 @@
 ::: jumanji.environments.routing.cleaner.env.Cleaner
+    selection:
+      members:
+        - __init__
+        - reset
+        - step
+        - observation_spec
+        - action_spec
+        - render

--- a/docs/api/environments/connector.md
+++ b/docs/api/environments/connector.md
@@ -1,7 +1,7 @@
 ::: jumanji.environments.routing.connector.env.Connector
     selection:
       members:
-        - init
+        - __init__
         - observation_spec
         - action_spec
         - reset

--- a/jumanji/environments/routing/cleaner/env.py
+++ b/jumanji/environments/routing/cleaner/env.py
@@ -91,14 +91,13 @@ class Cleaner(Environment[State, specs.MultiDiscreteArray, Observation]):
         """Instantiates a `Cleaner` environment.
 
         Args:
-            num_agents: number of agents. Defaults to 3.
-            time_limit: max number of steps in an episode. Defaults to `num_rows * num_cols`.
             generator: `Generator` whose `__call__` instantiates an environment instance.
                 Implemented options are [`RandomGenerator`]. Defaults to `RandomGenerator` with
                 `num_rows=10`, `num_cols=10` and `num_agents=3`.
+            time_limit: max number of steps in an episode. Defaults to `num_rows * num_cols`.
+            penalty_per_timestep: the penalty returned at each timestep in the reward.
             viewer: `Viewer` used for rendering. Defaults to `CleanerViewer` with "human" render
                 mode.
-            penalty_per_timestep: the penalty returned at each timestep in the reward.
         """
         self.generator = generator or RandomGenerator(
             num_rows=10, num_cols=10, num_agents=3

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -9,6 +9,7 @@ mkdocs-git-revision-date-plugin==0.3.2
 mkdocs-include-markdown-plugin==4.0.4
 mkdocs-material==8.2.7
 mkdocs-mermaid2-plugin==0.6.0
+mkdocs_autorefs<1.0
 mkdocstrings==0.18.0
 mknotebooks==0.7.1
 mypy==0.991


### PR DESCRIPTION
Removes `num_agents` from cleaner's `__init__` docs

Closes #203 