### PR TITLE
fix: Require jax below 0.4.36

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@ chex>=0.1.3
 dm-env>=1.5
 gymnasium>=1.0
 huggingface-hub
-jax>=0.2.26
+jax>=0.2.26,<0.4.36
 matplotlib~=3.7.4
 numpy>=1.19.5
 Pillow>=9.0.0


### PR DESCRIPTION
Restrict JAX to below latest 0.4.36 release due to [this issue](https://github.com/jax-ml/jax/issues/25332)