### PR TITLE
Fix bug in Graph Coloring

### DIFF
--- a/jumanji/environments/logic/graph_coloring/env.py
+++ b/jumanji/environments/logic/graph_coloring/env.py
@@ -178,7 +178,7 @@ class GraphColoring(Environment[State, specs.DiscreteArray, Observation]):
         # Update the current node index
         next_node_index = (state.current_node_index + 1) % self.num_nodes
 
-        next_action_mask = self._get_valid_actions(next_node_index, state.adj_matrix, state.colors)
+        next_action_mask = self._get_valid_actions(next_node_index, state.adj_matrix, colors)
 
         next_state = State(
             adj_matrix=state.adj_matrix,


### PR DESCRIPTION
Bug in graph coloring where the legal actions were computed based on the previous state, not the current state. This meant that if nodes `i` and `i+1` are adjacent, they could be colored with the same color.

Repro script:
```
import jax
from jumanji.environments.logic.graph_coloring.env import GraphColoring
from jumanji.environments.logic.graph_coloring.generator import Generator
from jumanji.types import StepType
import chex
import jax.numpy as jnp

class BugReproGenerator(Generator):
    def __init__(self):
        pass

    @property
    def num_nodes(self) -> int:
        return 3

    def __call__(self, key: chex.PRNGKey) -> chex.Array:
        adj_matrix = jnp.array([
            [0, 1, 1],
            [1, 0, 1],
            [1, 1, 0],
        ])
        return adj_matrix

env = GraphColoring(
    generator=BugReproGenerator(),
)
key = jax.random.PRNGKey(0)
state, timestep = jax.jit(env.reset)(key)

print("- State at step 0:")
print(state)
action = 0
print("- Coloring node 0 with color 0")
state, timestep = jax.jit(env.step)(state, action)
print("- State at step 1:")
print(state)
action = 0
print("- Coloring node 1 with color 0")
state, timestep = jax.jit(env.step)(state, action)
print("Episode finished: ", timestep.step_type == StepType.LAST)
```

The above script creates a fully-connected graph of 3 nodes (a triangle).  
Before fix, the output of the above script:
```
- State at step 0:
State(adj_matrix=Array([[0, 1, 1],
       [1, 0, 1],
       [1, 1, 0]], dtype=int32), colors=Array([-1, -1, -1], dtype=int32), current_node_index=Array(0, dtype=int32), action_mask=Array([ True,  True,  True], dtype=bool), key=Array([4146024105,  967050713], dtype=uint32))
- Coloring node 0 with color 0
- State at step 1:
State(adj_matrix=Array([[0, 1, 1],
       [1, 0, 1],
       [1, 1, 0]], dtype=int32), colors=Array([ 0, -1, -1], dtype=int32), current_node_index=Array(1, dtype=int32), action_mask=Array([ True,  True,  True], dtype=bool), key=Array([4146024105,  967050713], dtype=uint32))
- Coloring node 1 with color 0
Episode finished:  False
```

After fix, the output of the above script:
```
- State at step 0:
State(adj_matrix=Array([[0, 1, 1],
       [1, 0, 1],
       [1, 1, 0]], dtype=int32), colors=Array([-1, -1, -1], dtype=int32), current_node_index=Array(0, dtype=int32), action_mask=Array([ True,  True,  True], dtype=bool), key=Array([4146024105,  967050713], dtype=uint32))
- Coloring node 0 with color 0
- State at step 1:
State(adj_matrix=Array([[0, 1, 1],
       [1, 0, 1],
       [1, 1, 0]], dtype=int32), colors=Array([ 0, -1, -1], dtype=int32), current_node_index=Array(1, dtype=int32), action_mask=Array([False,  True,  True], dtype=bool), key=Array([4146024105,  967050713], dtype=uint32))
- Coloring node 1 with color 0
Episode finished:  True
```

Note the `action_mask` of the State at step 1. Since Node 0 is already colored with color 0, it should be illegal to color Node 1 with the same color. However, before the fix, all actions are legal. After the fix, the 0th action is correctly illegal.