### PR TITLE
docs: add test coverage badge (#101)

### DIFF
--- a/.github/workflows/tests_linters.yml
+++ b/.github/workflows/tests_linters.yml
@@ -40,12 +40,20 @@ jobs:
         run: pre-commit run --all-files --verbose
 
       - name: Run tests 🧪
-        run: pytest -n 2 --cov=jumanji --cov-report=term-missing --junit-xml=test-results.xml -vv jumanji
+        run: pytest -n 2 --cov=jumanji --cov-report=term-missing --cov-report=xml --junit-xml=test-results.xml -vv jumanji
 
       - name: Run coverage
         run: |
           coverage html --directory=coverage_html_report
           coverage report --fail-under=0.97
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
 
       - name: Test build docs 📖
         run: mkdocs build --verbose --site-dir docs_public

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Python Versions](https://img.shields.io/pypi/pyversions/jumanji.svg?style=flat-square)](https://www.python.org/doc/versions/)
 [![PyPI Version](https://badge.fury.io/py/jumanji.svg)](https://badge.fury.io/py/jumanji)
 [![Tests](https://github.com/instadeepai/jumanji/actions/workflows/tests_linters.yml/badge.svg)](https://github.com/instadeepai/jumanji/actions/workflows/tests_linters.yml)
+[![Coverage](https://codecov.io/gh/instadeepai/jumanji/branch/main/graph/badge.svg)](https://codecov.io/gh/instadeepai/jumanji)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![MyPy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg)](https://opensource.org/licenses/Apache-2.0)


### PR DESCRIPTION
The implementation leverages existing infrastructure and adds minimal complexity while providing valuable visibility into test coverage. The badge will automatically update with each CI run, providing real-time coverage information to contributors and users.