### PR TITLE
fix(wrappers): MultiToSingleWrapper is not updating reward and discount specs

### DIFF
--- a/jumanji/wrappers.py
+++ b/jumanji/wrappers.py
@@ -294,6 +294,24 @@ class MultiToSingleWrapper(
         timestep = self._aggregate_timestep(timestep)
         return state, timestep
 
+    @cached_property
+    def reward_spec(self) -> specs.Array:
+        """Scalar reward spec matching the aggregated output."""
+        return specs.Array(
+            shape=(), dtype=self._env.reward_spec.dtype, name=self._env.reward_spec.name
+        )
+
+    @cached_property
+    def discount_spec(self) -> specs.BoundedArray:
+        """Scalar discount spec matching the aggregated output."""
+        return specs.BoundedArray(
+            shape=(),
+            dtype=self._env.discount_spec.dtype,
+            minimum=self._env.discount_spec.minimum.min(),
+            maximum=self._env.discount_spec.maximum.max(),
+            name=self._env.discount_spec.name,
+        )
+
 
 class VmapWrapper(Wrapper[State, ActionSpec, Observation], Generic[State, ActionSpec, Observation]):
     """Vectorized Jax env.

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -2,7 +2,7 @@ coverage
 livereload
 mkdocs==1.6.1
 mkdocs-git-revision-date-plugin==0.3.2
-mkdocs-include-markdown-plugin==7.1.1
+mkdocs-include-markdown-plugin==7.1.8
 mkdocs-material==9.5.45
 mkdocs-mermaid2-plugin==1.1.0
 mkdocs_autorefs==1.2.0


### PR DESCRIPTION
`MultiToSingleWrapper` updates reward and discount to a scalar but is not updating reward and discount specs to reduce shape to `()`