### PR TITLE
Use functools.partial instead of lambdas for lax.cond branches (#245)

### DIFF
--- a/jumanji/environments/logic/game_2048/env.py
+++ b/jumanji/environments/logic/game_2048/env.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import cached_property
+from functools import cached_property, partial
 from typing import Optional, Sequence, Tuple
 
 import chex
@@ -217,16 +217,10 @@ class Game2048(Environment[State, specs.DiscreteArray, Observation]):
         extras = {"highest_tile": highest_tile}
         timestep = jax.lax.cond(
             done,
-            lambda: termination(
-                reward=reward,
-                observation=observation,
-                extras=extras,
-            ),
-            lambda: transition(
-                reward=reward,
-                observation=observation,
-                extras=extras,
-            ),
+            partial(termination, extras=extras),
+            partial(transition, extras=extras),
+            reward,
+            observation,
         )
 
         return state, timestep

--- a/jumanji/environments/logic/sliding_tile_puzzle/env.py
+++ b/jumanji/environments/logic/sliding_tile_puzzle/env.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import cached_property
+from functools import cached_property, partial
 from typing import Dict, Optional, Sequence, Tuple
 
 import chex
@@ -144,16 +144,10 @@ class SlidingTilePuzzle(Environment[State, specs.DiscreteArray, Observation]):
 
         timestep = jax.lax.cond(
             done | (next_state.step_count >= self.time_limit),
-            lambda: termination(
-                reward=reward,
-                observation=obs,
-                extras=extras,
-            ),
-            lambda: transition(
-                reward=reward,
-                observation=obs,
-                extras=extras,
-            ),
+            partial(termination, extras=extras),
+            partial(transition, extras=extras),
+            reward,
+            obs,
         )
 
         return next_state, timestep

--- a/jumanji/environments/packing/bin_pack/env.py
+++ b/jumanji/environments/packing/bin_pack/env.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import itertools
-from functools import cached_property
+from functools import cached_property, partial
 from typing import Dict, Optional, Sequence, Tuple
 
 import chex
@@ -334,16 +334,10 @@ class BinPack(Environment[State, specs.MultiDiscreteArray, Observation]):
 
         timestep = jax.lax.cond(
             done,
-            lambda: termination(
-                reward=reward,
-                observation=observation,
-                extras=extras,
-            ),
-            lambda: transition(
-                reward=reward,
-                observation=observation,
-                extras=extras,
-            ),
+            partial(termination, extras=extras),
+            partial(transition, extras=extras),
+            reward,
+            observation,
         )
 
         return next_state, timestep

--- a/jumanji/environments/routing/sokoban/env.py
+++ b/jumanji/environments/routing/sokoban/env.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import cached_property
+from functools import cached_property, partial
 from typing import Dict, Optional, Sequence, Tuple
 
 import chex
@@ -243,16 +243,10 @@ class Sokoban(Environment[State, specs.DiscreteArray, Observation]):
 
         timestep = jax.lax.cond(
             done,
-            lambda: termination(
-                reward=reward,
-                observation=observation,
-                extras=extras,
-            ),
-            lambda: transition(
-                reward=reward,
-                observation=observation,
-                extras=extras,
-            ),
+            partial(termination, extras=extras),
+            partial(transition, extras=extras),
+            reward,
+            observation,
         )
 
         return next_state, timestep


### PR DESCRIPTION
Addresses #245. Replaces the lambda-wrapped jax.lax.cond branches with the
functools.partial direct-call style already used in search_and_rescue, in four
environments: game_2048, sliding_tile_puzzle, bin_pack, and sokoban. reward and
observation are passed as cond operands and extras is bound via partial.

Behaviour preserving: termination has no `discount` parameter while
transition/truncation do, so extras is bound by keyword to keep both branches
correct. All existing tests for the four environments pass locally (35 passed).

Note: connector is intentionally left unchanged. Its lax.switch term_fn adapts
termination's differing signature (it drops discount), so that lambda is
load-bearing rather than redundant. Happy to revisit if a named helper is preferred.