### PR TITLE
docs: remove Contributor License Agreement requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,6 @@ and then open a PR from the fork to the jumanji repository.
 Before sending your pull requests, make sure you do the following:
 - Read the [contributing guidelines](#Contributing-Code).
 - Read the [Code of Conduct](#Code-of-Conduct).
-- Ensure you have signed the [Contributor License Agreement](#Contributor-License-Agreement) (CLA).
 - Check if your changes are consistent with the [guidelines](#General-guidelines-and-philosophy-for-contribution) and the [Coding Style](#Coding-Style).
 - Run the [unit tests](#Testing).
 - Run the [pre-commits](#Pre-Commit).
@@ -83,12 +82,3 @@ We ask you to help us develop a positive working environment. Behaviours that co
 ### Testing
 Please make sure that your PR passes all tests by running [pytest](https://docs.pytest.org/en/latest/) (`uv run pytest`) on your local machine.
 Also, you can run only tests that are affected by your code changes, but you will need to select them manually.
-
-### Contributor License Agreement
-Contributions to this project must be accompanied by a Contributor License Agreement.
-You (or your employer) retain the copyright to your contribution, this simply gives us permission to use and
-redistribute your contributions as part of the project. Head over to https://cla.developers.google.com/ to
-see your current agreements on file or to sign a new one.
-
-You generally only need to submit a CLA once, so if you've already submitted one
-(even if it was for a different project), you probably don't need to do it again.

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ For more information on how to use the example agents, see the
 Contributions are welcome! See our issue tracker for
 [good first issues](https://github.com/instadeepai/jumanji/labels/good%20first%20issue). Please read
 our [contributing guidelines](https://github.com/instadeepai/jumanji/blob/main/CONTRIBUTING.md) for
-details on how to submit pull requests, our Contributor License Agreement, and community guidelines.
+details on how to submit pull requests and our community guidelines.
 
 <h2 name="citing" id="citing">Citing Jumanji ✏️</h2>
 


### PR DESCRIPTION
## What

Removes the Contributor License Agreement (CLA) from the contributing docs:
- Drops the `### Contributor License Agreement` section and the checklist item in `CONTRIBUTING.md`.
- Removes the CLA mention in `README.md`.

## Why

- The CLA section pointed contributors to **Google's** CLA (`cla.developers.google.com`) — an inherited template artifact that was never InstaDeep's process.
- The `cla-assistant.io` integration that used to enforce it has been **removed** (no repo webhook, app uninstalled), so the `license/cla` check no longer runs on recent PRs (e.g. #303). The docs were promising a signing flow that doesn't exist.
- **No other InstaDeep public repo uses a CLA or DCO** — winnow, mlipaudit, mlip (Apache-2.0), catx (MIT), InstaNovo (Apache-2.0) all rely on inbound=outbound licensing with no CLA/DCO check.
- Jumanji is Apache-2.0, whose license grant already covers redistribution and includes an explicit patent grant, so a CLA adds little here. This aligns jumanji with the rest of the org.

> Note: whether to keep any CLA is ultimately a legal/policy call. If InstaDeep legal wants relicensing rights preserved on jumanji, we should instead re-add a CLA via the maintained in-repo action (`contributor-assistant/github-action`) rather than the removed hosted service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)