### PR TITLE
chore: bump version to 1.1.2

### DIFF
--- a/jumanji/version.py
+++ b/jumanji/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"


### PR DESCRIPTION
Bumps `jumanji/version.py` from `1.1.1` → `1.1.2` in preparation for the next release.

**Patch bump rationale:** the changes since v1.1.1 are bug fixes, build/tooling (uv + astral migration), and a wrapper performance improvement (`VmapAutoResetWrapper`). No new or breaking public API, so a patch release is appropriate rather than a minor bump.

Merge this after the other pending PRs land, then publish the `v1.1.2` GitHub Release to trigger the PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)