### PR TITLE
feat: expose state and key in DMEnvWrapper

### DIFF
--- a/jumanji/wrappers.py
+++ b/jumanji/wrappers.py
@@ -137,10 +137,10 @@ class JumanjiToDMEnvWrapper(dm_env.Environment, Generic[State, ActionSpec, Obser
         """
         self._env = env
         if key is None:
-            self._key = jax.random.PRNGKey(0)
+            self.key = jax.random.PRNGKey(0)
         else:
-            self._key = key
-        self._state: Any
+            self.key = key
+        self.state: State
         self._jitted_reset: Callable[[chex.PRNGKey], Tuple[State, TimeStep]] = jax.jit(
             self._env.reset
         )
@@ -164,8 +164,8 @@ class JumanjiToDMEnvWrapper(dm_env.Environment, Generic[State, ActionSpec, Obser
                     are also valid in place of a scalar array. Must conform to the
                     specification returned by `observation_spec`.
         """
-        reset_key, self._key = jax.random.split(self._key)
-        self._state, timestep = self._jitted_reset(reset_key)
+        reset_key, self.key = jax.random.split(self.key)
+        self.state, timestep = self._jitted_reset(reset_key)
         return dm_env.restart(observation=timestep.observation)
 
     def step(self, action: chex.ArrayNumpy) -> dm_env.TimeStep:
@@ -197,7 +197,7 @@ class JumanjiToDMEnvWrapper(dm_env.Environment, Generic[State, ActionSpec, Obser
                     are also valid in place of a scalar array. Must conform to the
                     specification returned by `observation_spec`.
         """
-        self._state, timestep = self._jitted_step(self._state, action)
+        self.state, timestep = self._jitted_step(self.state, action)
         return dm_env.TimeStep(
             step_type=timestep.step_type,
             reward=timestep.reward,

--- a/jumanji/wrappers_test.py
+++ b/jumanji/wrappers_test.py
@@ -207,6 +207,23 @@ class TestJumanjiEnvironmentToDeepMindEnv:
         )
         assert isinstance(dm_environment_with_key, dm_env.Environment)
 
+    def test_jumanji_environment_to_deep_mind_env__state_and_key_attributes(
+        self,
+        fake_environment: FakeEnvironment,
+        key: chex.PRNGKey,
+    ) -> None:
+        """Validates getting and setting the wrapper's state and key attributes."""
+        dm_environment = JumanjiToDMEnvWrapper(fake_environment, key=key)
+        assert dm_environment.key is key
+
+        new_key = jax.random.PRNGKey(1)
+        dm_environment.key = new_key
+        assert dm_environment.key is new_key
+
+        state = FakeState(key=key, step=jnp.array(0, jnp.int32))
+        dm_environment.state = state
+        assert dm_environment.state is state
+
     def test_dm_env__reset(self, fake_dm_env: FakeJumanjiToDMEnvWrapper) -> None:
         """Validates reset function and timestep type of the wrapped environment."""
         timestep = fake_dm_env.reset()


### PR DESCRIPTION
## Summary

Expose the state and PRNG key held by `JumanjiToDMEnvWrapper` as writable public attributes. This allows callers to save and restore wrapped environment state for planning without accessing private attributes.

The implementation uses direct attributes, following the maintainer feedback in #30, and adds one focused test covering retrieval, assignment, and reference identity.

Closes #27.

## Testing

- `uv run pre-commit run --all-files`
- `uv run pytest jumanji/wrappers_test.py -q` (`51 passed`)
- `uv run pytest` (`817 passed`, `3 skipped`; one unrelated Search-and-Rescue floating-point boundary test failed and reproduces on the unchanged upstream implementation)

AI-assisted: Yes.
